### PR TITLE
Add wrapper package builds to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+      - name: Build wrapper packages
+        run: pnpm -r --filter='!@tessera-ui/docs' run build
       - uses: actions/upload-artifact@v4
         with:
           name: dist


### PR DESCRIPTION
## Summary
Closes #7

- Add step to CI build job to compile react, vue, and angular wrapper packages after core build
- Ensures broken wrapper builds are caught before merge

## Test plan
- [ ] CI workflow includes wrapper build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)