### PR TITLE
Fix flaky E2E tests with browser stability config

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -66,7 +66,14 @@ export const config: Config = {
 
   testing: {
     browserHeadless: 'new',
-    browserArgs: ['--no-sandbox', '--disable-setuid-sandbox'],
+    browserArgs: [
+      '--no-sandbox',
+      '--disable-setuid-sandbox',
+      '--disable-gpu',
+      '--disable-dev-shm-usage',
+    ],
+    browserWaitUntil: 'load',
+    testTimeout: 60000,
     setupFilesAfterFramework: ['./tests/setup.ts'],
   },
 };


### PR DESCRIPTION
## Summary
Closes #12

- Add `--disable-gpu` and `--disable-dev-shm-usage` browser args to prevent resource-related timeouts in CI
- Increase test timeout from 30s (default) to 60s
- Set `browserWaitUntil` to `load` for consistent page readiness

## Test plan
- [ ] `pnpm test.e2e` — 154 tests pass
- [ ] CI E2E job passes without timeout failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)