### PR TITLE
Improve CI performance with caching and job consolidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
@@ -61,7 +63,9 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
@@ -103,7 +107,9 @@ jobs:
         id: cache-modules
         uses: actions/cache@v4
         with:
-          path: node_modules
+          path: |
+            node_modules
+            packages/*/node_modules
           key: modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Cache `node_modules` keyed on `pnpm-lock.yaml` hash — skips install entirely on cache hit
- Cache Playwright browsers to avoid re-downloading chromium each run
- Merge lint + unit tests into one job (eliminates a full install cycle)
- Run all 3 jobs in parallel (build no longer waits for tests)
- Add wrapper package builds to build job
- Extract Node/pnpm versions to env vars

### Before
- 4 jobs, each running `pnpm install` independently
- Build waits for lint + unit tests to finish
- Playwright downloads chromium every run

### After
- 3 jobs, all run in parallel
- `node_modules` cached — install only runs when lockfile changes
- Playwright browsers cached

## Test plan
- [ ] CI passes on this PR
- [ ] Cache hit visible in subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)