### PR TITLE
Fix card overflow, nav aria-label, button Space key

### DIFF
--- a/src/components/button/button.e2e.ts
+++ b/src/components/button/button.e2e.ts
@@ -49,6 +49,20 @@ describe('ts-button e2e', () => {
     expect(tsClick).toHaveReceivedEvent();
   });
 
+  it('fires tsClick on Space key when href is set', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-button href="https://example.com">Link</ts-button>');
+
+    const tsClick = await page.spyOnEvent('tsClick');
+
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+    await page.keyboard.press('Space');
+    await page.waitForChanges();
+
+    expect(tsClick).toHaveReceivedEvent();
+  });
+
   it('does not fire tsClick when disabled', async () => {
     const page = await newE2EPage();
     await page.setContent('<ts-button disabled>Disabled</ts-button>');

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -74,6 +74,13 @@ export class TsButton {
     this.tsBlur.emit();
   };
 
+  private handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === ' ' && this.href) {
+      event.preventDefault();
+      (event.currentTarget as HTMLElement).click();
+    }
+  };
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   private renderSpinner() {
     return (
@@ -123,6 +130,7 @@ export class TsButton {
           onClick={this.handleClick}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
+          onKeyDown={this.handleKeyDown}
         >
           {this.loading && this.renderSpinner()}
 

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -20,7 +20,6 @@
   border-radius: var(--ts-card-radius);
   background-color: var(--ts-card-bg);
   border: 1px solid transparent;
-  overflow: hidden;
   transition:
     box-shadow var(--ts-transition-normal),
     transform var(--ts-transition-normal),

--- a/src/components/nav/nav.spec.ts
+++ b/src/components/nav/nav.spec.ts
@@ -43,6 +43,16 @@ describe('ts-nav', () => {
     expect(list?.getAttribute('role')).toBe('list');
   });
 
+  it('uses custom label prop for aria-label', async () => {
+    const page = await newSpecPage({
+      components: [TsNav],
+      html: '<ts-nav label="Main menu"></ts-nav>',
+    });
+
+    const nav = page.root?.shadowRoot?.querySelector('nav');
+    expect(nav?.getAttribute('aria-label')).toBe('Main menu');
+  });
+
   it('applies sidebar variant class', async () => {
     const page = await newSpecPage({
       components: [TsNav],

--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -18,6 +18,9 @@ export class TsNav {
   /** Whether the sidebar nav is collapsed (icons only). */
   @Prop({ reflect: true }) collapsed = false;
 
+  /** Accessible label for the nav element. */
+  @Prop() label = 'Navigation';
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
     return (
@@ -28,7 +31,7 @@ export class TsNav {
           'ts-nav--collapsed': this.collapsed,
         }}
       >
-        <nav class="nav__native" part="nav" aria-label="Navigation">
+        <nav class="nav__native" part="nav" aria-label={this.label}>
           <ul class="nav__list" part="list" role="list">
             <slot />
           </ul>


### PR DESCRIPTION
## Summary
Closes #36, closes #29, closes #28

- Remove overflow:hidden from card to prevent clipping child content
- Add label prop to nav for customizable aria-label
- Add Space key handler for button with href

## Test plan
- [ ] pnpm build passes
- [ ] pnpm test passes
- [ ] pnpm test.e2e passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)