### PR TITLE
Fix tree ARIA, focus trap shadow DOM, select multiple

### DIFF
--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -154,6 +154,23 @@
   cursor: not-allowed;
 }
 
+/* ---- Checkmark (multiple mode) ---- */
+.select__check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  margin-inline-end: var(--ts-spacing-2);
+  color: var(--ts-color-interactive-primary);
+}
+
+.select__check svg {
+  width: 100%;
+  height: 100%;
+}
+
 /* ---- Sizes ---- */
 :host([size="sm"]) .select__trigger {
   padding: var(--ts-spacing-1) var(--ts-spacing-2);

--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -111,4 +111,74 @@ describe('ts-select', () => {
     const trigger = page.root?.shadowRoot?.querySelector('.select__trigger');
     expect(trigger?.hasAttribute('disabled')).toBe(true);
   });
+
+  it('reflects multiple prop', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select multiple>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-select>`,
+    });
+
+    expect(page.root).toHaveAttribute('multiple');
+  });
+
+  it('stores multiple values as comma-separated string', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select multiple value="a,b">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+        <option value="c">Option C</option>
+      </ts-select>`,
+    });
+
+    expect(page.root?.getAttribute('value')).toBe('a,b');
+  });
+
+  it('shows selected count for multiple selections', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select multiple value="a,b">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+        <option value="c">Option C</option>
+      </ts-select>`,
+    });
+
+    const display = page.root?.shadowRoot?.querySelector('.select__display');
+    expect(display?.textContent).toContain('2 selected');
+  });
+
+  it('shows single value when one item selected in multiple mode', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select multiple value="a">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-select>`,
+    });
+
+    const display = page.root?.shadowRoot?.querySelector('.select__display');
+    // In spec tests, slotted options may not populate; display shows label or value fallback
+    expect(display?.textContent?.trim()).toBeTruthy();
+  });
+
+  it('renders aria-multiselectable on listbox in multiple mode', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select multiple>
+        <option value="a">Option A</option>
+      </ts-select>`,
+    });
+
+    // Open the dropdown by simulating trigger click
+    const select = page.rootInstance as TsSelect;
+    (select as unknown as { isOpen: boolean }).isOpen = true;
+    await page.waitForChanges();
+
+    const listbox = page.root?.shadowRoot?.querySelector('[role="listbox"]');
+    expect(listbox?.getAttribute('aria-multiselectable')).toBe('true');
+  });
 });

--- a/src/components/select/select.stories.ts
+++ b/src/components/select/select.stories.ts
@@ -131,3 +131,22 @@ export const CategoryFilter = (): string => `
     </ts-select>
   </div>
 `;
+
+export const Multiple = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 24px; max-width: 320px;">
+    <ts-select multiple label="Departments" placeholder="Select departments" help-text="Choose one or more departments.">
+      <option value="engineering">Engineering</option>
+      <option value="design">Design</option>
+      <option value="marketing">Marketing</option>
+      <option value="sales">Sales</option>
+      <option value="support">Support</option>
+    </ts-select>
+    <ts-select multiple label="Tags" placeholder="Add tags" value="frontend,react">
+      <option value="frontend">Frontend</option>
+      <option value="backend">Backend</option>
+      <option value="react">React</option>
+      <option value="typescript">TypeScript</option>
+      <option value="css">CSS</option>
+    </ts-select>
+  </div>
+`;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -113,10 +113,29 @@ export class TsSelect {
     }));
   }
 
+  private getSelectedValues(): string[] {
+    if (!this.value) return [];
+    return this.value.split(',').filter(Boolean);
+  }
+
+  private isOptionSelected(option: SelectOption): boolean {
+    if (this.multiple) {
+      return this.getSelectedValues().includes(option.value);
+    }
+    return option.value === this.value;
+  }
+
   private open(): void {
     if (this.disabled) return;
     this.isOpen = true;
-    this.focusedIndex = this.options.findIndex((o) => o.value === this.value);
+    if (this.multiple) {
+      const selectedValues = this.getSelectedValues();
+      this.focusedIndex = selectedValues.length > 0
+        ? this.options.findIndex((o) => o.value === selectedValues[0])
+        : 0;
+    } else {
+      this.focusedIndex = this.options.findIndex((o) => o.value === this.value);
+    }
     if (this.focusedIndex < 0) this.focusedIndex = 0;
   }
 
@@ -128,9 +147,23 @@ export class TsSelect {
 
   private selectOption(option: SelectOption): void {
     if (option.disabled) return;
-    this.value = option.value;
-    this.tsChange.emit({ value: this.value });
-    this.close();
+
+    if (this.multiple) {
+      const selected = this.getSelectedValues();
+      const index = selected.indexOf(option.value);
+      if (index >= 0) {
+        selected.splice(index, 1);
+      } else {
+        selected.push(option.value);
+      }
+      this.value = selected.join(',');
+      this.tsChange.emit({ value: this.value });
+      // Don't close dropdown in multiple mode
+    } else {
+      this.value = option.value;
+      this.tsChange.emit({ value: this.value });
+      this.close();
+    }
   }
 
   private handleTriggerClick = (): void => {
@@ -222,6 +255,15 @@ export class TsSelect {
   };
 
   private getDisplayText(): string {
+    if (this.multiple) {
+      const selectedValues = this.getSelectedValues();
+      if (selectedValues.length === 0) return '';
+      if (selectedValues.length === 1) {
+        const match = this.options.find((o) => o.value === selectedValues[0]);
+        return match?.label ?? selectedValues[0];
+      }
+      return `${selectedValues.length} selected`;
+    }
     const selected = this.options.find((o) => o.value === this.value);
     return selected?.label ?? '';
   }
@@ -291,25 +333,38 @@ export class TsSelect {
               role="listbox"
               id={listboxId}
               aria-labelledby={this.label ? labelId : undefined}
+              aria-multiselectable={this.multiple ? 'true' : undefined}
               onKeyDown={this.handleDropdownKeydown}
             >
-              {this.options.map((option, index) => (
-                <div
-                  class={{
-                    'select__option': true,
-                    'select__option--selected': option.value === this.value,
-                    'select__option--focused': index === this.focusedIndex,
-                    'select__option--disabled': option.disabled,
-                  }}
-                  part="option"
-                  role="option"
-                  aria-selected={option.value === this.value ? 'true' : 'false'}
-                  aria-disabled={option.disabled ? 'true' : undefined}
-                  onClick={() => this.selectOption(option)}
-                >
-                  {option.label}
-                </div>
-              ))}
+              {this.options.map((option, index) => {
+                const selected = this.isOptionSelected(option);
+                return (
+                  <div
+                    class={{
+                      'select__option': true,
+                      'select__option--selected': selected,
+                      'select__option--focused': index === this.focusedIndex,
+                      'select__option--disabled': option.disabled,
+                    }}
+                    part="option"
+                    role="option"
+                    aria-selected={selected ? 'true' : 'false'}
+                    aria-disabled={option.disabled ? 'true' : undefined}
+                    onClick={() => this.selectOption(option)}
+                  >
+                    {this.multiple && (
+                      <span class="select__check" aria-hidden="true">
+                        {selected ? (
+                          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
+                          </svg>
+                        ) : null}
+                      </span>
+                    )}
+                    {option.label}
+                  </div>
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/components/tree/tree-item.tsx
+++ b/src/components/tree/tree-item.tsx
@@ -36,6 +36,7 @@ export class TsTreeItem {
   /** Whether this item has slotted children (expandable). */
   @State() hasChildren = false;
 
+
   /** Emitted when expand/collapse is toggled. */
   @Event({ eventName: 'tsToggle' }) tsToggle!: EventEmitter<{ expanded: boolean }>;
 
@@ -49,6 +50,39 @@ export class TsTreeItem {
 
   componentDidLoad(): void {
     this.checkForChildren();
+  }
+
+  private getAriaLevel(): number {
+    let level = 1;
+    let parent = this.hostEl.parentElement;
+    while (parent) {
+      if (parent.tagName === 'TS-TREE-ITEM') {
+        level++;
+      }
+      parent = parent.parentElement;
+    }
+    return level;
+  }
+
+  private getAriaSetSize(): number {
+    const container = this.hostEl.parentElement;
+    if (container) {
+      return Array.from(container.children).filter(
+        (el) => el.tagName === 'TS-TREE-ITEM'
+      ).length;
+    }
+    return 1;
+  }
+
+  private getAriaPosInSet(): number {
+    const container = this.hostEl.parentElement;
+    if (container) {
+      const siblings = Array.from(container.children).filter(
+        (el) => el.tagName === 'TS-TREE-ITEM'
+      );
+      return siblings.indexOf(this.hostEl) + 1;
+    }
+    return 1;
   }
 
   private checkForChildren(): void {
@@ -101,6 +135,9 @@ export class TsTreeItem {
         aria-expanded={this.hasChildren ? String(this.expanded) : undefined}
         aria-selected={String(this.selected)}
         aria-disabled={this.disabled ? 'true' : undefined}
+        aria-level={String(this.getAriaLevel())}
+        aria-setsize={String(this.getAriaSetSize())}
+        aria-posinset={String(this.getAriaPosInSet())}
         onKeyDown={this.handleKeyDown}
       >
         <div class="tree-item__base" part="base" onClick={this.handleSelect}>

--- a/src/components/tree/tree.spec.ts
+++ b/src/components/tree/tree.spec.ts
@@ -111,4 +111,50 @@ describe('ts-tree-item', () => {
 
     expect(page.root?.getAttribute('tabindex')).toBe('0');
   });
+
+  it('sets aria-level to 1 for root items', async () => {
+    const page = await newSpecPage({
+      components: [TsTree, TsTreeItem],
+      html: `<ts-tree>
+        <ts-tree-item label="Root"></ts-tree-item>
+      </ts-tree>`,
+    });
+    await page.waitForChanges();
+
+    const item = page.root?.querySelector('ts-tree-item');
+    expect(item?.getAttribute('aria-level')).toBe('1');
+  });
+
+  it('sets aria-setsize and aria-posinset for siblings', async () => {
+    const page = await newSpecPage({
+      components: [TsTree, TsTreeItem],
+      html: `<ts-tree>
+        <ts-tree-item label="First"></ts-tree-item>
+        <ts-tree-item label="Second"></ts-tree-item>
+        <ts-tree-item label="Third"></ts-tree-item>
+      </ts-tree>`,
+    });
+    await page.waitForChanges();
+
+    const items = page.root?.querySelectorAll('ts-tree-item');
+    expect(items?.[0]?.getAttribute('aria-setsize')).toBe('3');
+    expect(items?.[0]?.getAttribute('aria-posinset')).toBe('1');
+    expect(items?.[1]?.getAttribute('aria-posinset')).toBe('2');
+    expect(items?.[2]?.getAttribute('aria-posinset')).toBe('3');
+  });
+
+  it('sets aria-level to 2 for nested items', async () => {
+    const page = await newSpecPage({
+      components: [TsTree, TsTreeItem],
+      html: `<ts-tree>
+        <ts-tree-item label="Parent" expanded>
+          <ts-tree-item label="Child"></ts-tree-item>
+        </ts-tree-item>
+      </ts-tree>`,
+    });
+    await page.waitForChanges();
+
+    const child = page.root?.querySelector('ts-tree-item ts-tree-item');
+    expect(child?.getAttribute('aria-level')).toBe('2');
+  });
 });

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -54,26 +54,60 @@ export function prefersReducedMotion(): boolean {
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 }
 
+/** Focusable element selectors used by the focus trap. */
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+/**
+ * Recursively query focusable elements, traversing shadow DOM boundaries.
+ */
+export function queryFocusableElements(root: HTMLElement | ShadowRoot): HTMLElement[] {
+  const result: HTMLElement[] = [];
+
+  // Query focusable elements at this level
+  const elements = root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS);
+  for (const el of Array.from(elements)) {
+    result.push(el);
+  }
+
+  // Walk all child elements to check for shadow roots
+  const allElements = root.querySelectorAll<HTMLElement>('*');
+  for (const el of Array.from(allElements)) {
+    if (el.shadowRoot) {
+      result.push(...queryFocusableElements(el.shadowRoot));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get the deepest active element, traversing shadow DOM boundaries.
+ */
+function getDeepActiveElement(): Element | null {
+  let active = document.activeElement;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+}
+
 /**
  * Trap focus within a container element.
+ * Traverses shadow DOM boundaries to find all focusable elements.
  * Returns a cleanup function to remove the trap.
  */
 export function trapFocus(container: HTMLElement): () => void {
-  const focusableSelectors = [
-    'a[href]',
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    '[tabindex]:not([tabindex="-1"])',
-  ].join(', ');
-
   function handleKeydown(event: KeyboardEvent): void {
     if (event.key !== 'Tab') return;
 
-    const focusableElements = Array.from(
-      container.querySelectorAll<HTMLElement>(focusableSelectors)
-    );
+    const focusableElements = queryFocusableElements(container);
 
     if (focusableElements.length === 0) {
       event.preventDefault();
@@ -82,14 +116,15 @@ export function trapFocus(container: HTMLElement): () => void {
 
     const firstFocusable = focusableElements[0];
     const lastFocusable = focusableElements[focusableElements.length - 1];
+    const deepActive = getDeepActiveElement();
 
     if (event.shiftKey) {
-      if (document.activeElement === firstFocusable) {
+      if (deepActive === firstFocusable || document.activeElement === firstFocusable) {
         event.preventDefault();
         lastFocusable.focus();
       }
     } else {
-      if (document.activeElement === lastFocusable) {
+      if (deepActive === lastFocusable || document.activeElement === lastFocusable) {
         event.preventDefault();
         firstFocusable.focus();
       }


### PR DESCRIPTION
## Summary
Closes #30, closes #22, closes #21

- Add aria-level, aria-setsize, aria-posinset to tree items
- Fix focus trap to traverse shadow DOM boundaries
- Implement select multiple mode with toggle selection

## Test plan
- [x] pnpm build passes
- [x] pnpm test passes (381 tests)
- [x] pnpm test.e2e passes (153/154 — 1 pre-existing toggle flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)