### PR TITLE
Fix Input tsChange previousValue always equaling current value

### DIFF
--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -113,6 +113,52 @@ describe('ts-input', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it('emits tsInput with correct previousValue', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input value="old"></ts-input>',
+    });
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsInput', spy);
+
+    const input = page.root?.shadowRoot?.querySelector('input');
+    if (input) {
+      input.value = 'new';
+      input.dispatchEvent(new Event('input'));
+    }
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    const detail = spy.mock.calls[0][0].detail;
+    expect(detail.value).toBe('new');
+    expect(detail.previousValue).toBe('old');
+  });
+
+  it('emits tsChange with correct previousValue after input', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input value="initial"></ts-input>',
+    });
+
+    const changeSpy = jest.fn();
+    page.root?.addEventListener('tsChange', changeSpy);
+
+    const input = page.root?.shadowRoot?.querySelector('input');
+    if (input) {
+      // Simulate typing (input event updates value)
+      input.value = 'updated';
+      input.dispatchEvent(new Event('input'));
+
+      // Simulate blur/commit (change event)
+      input.dispatchEvent(new Event('change'));
+    }
+
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    const detail = changeSpy.mock.calls[0][0].detail;
+    expect(detail.value).toBe('updated');
+    expect(detail.previousValue).toBe('initial');
+  });
+
   it('reflects the correct input type', async () => {
     const page = await newSpecPage({
       components: [TsInput],

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -36,6 +36,7 @@ export class TsInput {
 
   private inputEl?: HTMLInputElement;
   private inputId = generateId('ts-input');
+  private previousValue = '';
 
   /** The input's value. */
   @Prop({ mutable: true, reflect: true }) value = '';
@@ -128,13 +129,13 @@ export class TsInput {
 
   private handleInput = (event: Event): void => {
     const target = event.target as HTMLInputElement;
-    const previousValue = this.value;
+    this.previousValue = this.value;
     this.value = target.value;
-    this.tsInput.emit({ value: this.value, previousValue });
+    this.tsInput.emit({ value: this.value, previousValue: this.previousValue });
   };
 
   private handleChange = (): void => {
-    this.tsChange.emit({ value: this.value, previousValue: this.value });
+    this.tsChange.emit({ value: this.value, previousValue: this.previousValue });
 
     // Run native validation
     if (this.inputEl) {


### PR DESCRIPTION
## Summary
- Store previous value in a class field before `handleInput` mutates `this.value`
- Emit the stored previous value in `tsChange` event instead of the already-updated value
- Add unit tests verifying `previousValue` differs from `value`

Closes #23

## Test plan
- [x] Unit tests pass (`pnpm test -- --spec src/components/input/input.spec.ts`)
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)