### PR TITLE
Fix toast live region created and populated simultaneously

### DIFF
--- a/src/components/toast/toast.css
+++ b/src/components/toast/toast.css
@@ -19,6 +19,19 @@
   --ts-toast-max-width: 420px;
 }
 
+/* Keep the live region in the DOM but visually hidden when not open */
+:host(:not(.ts-toast--open)) {
+  position: fixed;
+  inline-size: 1px;
+  block-size: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---- Positions ---- */
 :host([position="top-right"]) {
   inset-block-start: var(--ts-spacing-4);

--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -2,7 +2,18 @@ import { newSpecPage } from '@stencil/core/testing';
 import { TsToast } from './toast';
 
 describe('ts-toast', () => {
-  it('renders nothing when not open', async () => {
+  it('always renders the live region container in the DOM', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast>Message</ts-toast>',
+    });
+
+    // The Host element should always have role="status" and aria-live
+    expect(page.root?.getAttribute('role')).toBe('status');
+    expect(page.root?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('renders empty container when not open (no visible content)', async () => {
     const page = await newSpecPage({
       components: [TsToast],
       html: '<ts-toast>Message</ts-toast>',
@@ -12,7 +23,7 @@ describe('ts-toast', () => {
     expect(base).toBeNull();
   });
 
-  it('renders when open is set', async () => {
+  it('renders content when open is set', async () => {
     const page = await newSpecPage({
       components: [TsToast],
       html: '<ts-toast open>Message</ts-toast>',
@@ -74,6 +85,16 @@ describe('ts-toast', () => {
     expect(page.root?.getAttribute('aria-live')).toBe('polite');
   });
 
+  it('sets aria-live on the container even when not open', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast variant="danger">Error!</ts-toast>',
+    });
+
+    expect(page.root?.getAttribute('role')).toBe('status');
+    expect(page.root?.getAttribute('aria-live')).toBe('assertive');
+  });
+
   it('emits tsClose when close button is clicked', async () => {
     const page = await newSpecPage({
       components: [TsToast],
@@ -96,5 +117,25 @@ describe('ts-toast', () => {
     });
 
     expect(page.root?.getAttribute('position')).toBe('bottom-left');
+  });
+
+  it('populates content into existing live region when opened', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast>Message</ts-toast>',
+    });
+
+    // Initially no content
+    let base = page.root?.shadowRoot?.querySelector('.toast__base');
+    expect(base).toBeNull();
+    // But live region exists
+    expect(page.root?.getAttribute('role')).toBe('status');
+
+    // Open the toast — content populates into existing live region
+    page.root!.open = true;
+    await page.waitForChanges();
+
+    base = page.root?.shadowRoot?.querySelector('.toast__base');
+    expect(base).not.toBeNull();
   });
 });

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -113,8 +113,6 @@ export class TsToast {
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
-    if (!this.isVisible) return null;
-
     const ariaLive = this.variant === 'danger' ? 'assertive' : 'polite';
 
     return (
@@ -128,31 +126,33 @@ export class TsToast {
         role="status"
         aria-live={ariaLive}
       >
-        <div class="toast__base" part="base">
-          <div class="toast__icon" part="icon">
-            {this.renderIcon()}
-          </div>
+        {this.isVisible && (
+          <div class="toast__base" part="base">
+            <div class="toast__icon" part="icon">
+              {this.renderIcon()}
+            </div>
 
-          <div class="toast__message" part="message">
-            <slot />
-          </div>
+            <div class="toast__message" part="message">
+              <slot />
+            </div>
 
-          <div class="toast__action" part="action">
-            <slot name="action" />
-          </div>
+            <div class="toast__action" part="action">
+              <slot name="action" />
+            </div>
 
-          {this.dismissible && (
-            <button
-              class="toast__close"
-              part="close"
-              type="button"
-              aria-label="Dismiss notification"
-              onClick={this.handleClose}
-            >
-              \u2715
-            </button>
-          )}
-        </div>
+            {this.dismissible && (
+              <button
+                class="toast__close"
+                part="close"
+                type="button"
+                aria-label="Dismiss notification"
+                onClick={this.handleClose}
+              >
+                \u2715
+              </button>
+            )}
+          </div>
+        )}
       </Host>
     );
   }


### PR DESCRIPTION
## Summary
- Always render the live region container (`role="status"`, `aria-live`) in the DOM
- Only populate message content when toast is visible (into already-existing container)
- Visually hide empty container with sr-only clip pattern
- Update tests to verify live region persists when closed

Closes #31

## Test plan
- [x] Unit tests pass (`pnpm test -- --spec src/components/toast/toast.spec.ts`)
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)