### PR TITLE
Add visually-hidden utility component

### DIFF
--- a/.ai-instructions.md
+++ b/.ai-instructions.md
@@ -41,7 +41,7 @@ tessera-ui/
 ├── .github/
 │   └── copilot-instructions.md # GitHub Copilot entry (loads this file)
 ├── src/
-│   ├── components/             # 39 Stencil web components
+│   ├── components/             # 40 Stencil web components
 │   │   ├── button/             # Reference component — match this pattern
 │   │   │   ├── button.tsx      # Component implementation
 │   │   │   ├── button.css      # Shadow DOM scoped styles
@@ -90,6 +90,7 @@ tessera-ui/
 │   │   ├── grid/               # CSS Grid with auto-fill columns
 │   │   ├── container/          # Centered max-width page container
 │   │   ├── spacer/             # Explicit spacing element
+│   │   ├── visually-hidden/     # Utility: screen-reader-only content
 │   │   ├── accordion/          # Compound: accordion + accordion-item
 │   │   └── tree/               # Compound: tree + tree-item
 │   ├── utils/                  # Shared utilities

--- a/src/components/visually-hidden/visually-hidden.css
+++ b/src/components/visually-hidden/visually-hidden.css
@@ -1,0 +1,31 @@
+/* ==========================================================================
+   ts-visually-hidden — Shadow DOM Scoped Styles
+
+   Utility component that visually hides content while keeping it
+   accessible to screen readers.
+   ========================================================================== */
+
+:host {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* When focusable, reset hiding styles on focus-within so skip links become visible */
+:host(.focusable:focus-within) {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+  white-space: normal;
+  border-width: 0;
+}

--- a/src/components/visually-hidden/visually-hidden.e2e.ts
+++ b/src/components/visually-hidden/visually-hidden.e2e.ts
@@ -1,0 +1,66 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-visually-hidden e2e', () => {
+  it('renders on the page', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-visually-hidden>Screen reader text</ts-visually-hidden>');
+
+    const element = await page.find('ts-visually-hidden');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('content is in the accessibility tree', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-visually-hidden>Important announcement</ts-visually-hidden>');
+
+    const text = await page.evaluate(() => {
+      const el = document.querySelector('ts-visually-hidden');
+      return el?.textContent?.trim();
+    });
+
+    expect(text).toBe('Important announcement');
+  });
+
+  it('is visually hidden with clip styles', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-visually-hidden>Hidden text</ts-visually-hidden>');
+
+    const dimensions = await page.evaluate(() => {
+      const el = document.querySelector('ts-visually-hidden');
+      const styles = window.getComputedStyle(el!);
+      return {
+        position: styles.position,
+        width: styles.width,
+        height: styles.height,
+        overflow: styles.overflow,
+      };
+    });
+
+    expect(dimensions.position).toBe('absolute');
+    expect(dimensions.width).toBe('1px');
+    expect(dimensions.height).toBe('1px');
+    expect(dimensions.overflow).toBe('hidden');
+  });
+
+  it('becomes visible when focusable and focused', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-visually-hidden focusable>
+        <a href="#main">Skip to main content</a>
+      </ts-visually-hidden>
+      <main id="main">Main content</main>
+    `);
+
+    // Tab to focus the skip link
+    await page.keyboard.press('Tab');
+    await page.waitForChanges();
+
+    const position = await page.evaluate(() => {
+      const el = document.querySelector('ts-visually-hidden');
+      const styles = window.getComputedStyle(el!);
+      return styles.position;
+    });
+
+    expect(position).toBe('static');
+  });
+});

--- a/src/components/visually-hidden/visually-hidden.spec.ts
+++ b/src/components/visually-hidden/visually-hidden.spec.ts
@@ -1,0 +1,66 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsVisuallyHidden } from './visually-hidden';
+
+describe('ts-visually-hidden', () => {
+  it('renders with default slot content', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden>Skip to main content</ts-visually-hidden>',
+    });
+
+    expect(page.root).not.toBeNull();
+    const span = page.root?.shadowRoot?.querySelector('span');
+    expect(span).not.toBeNull();
+  });
+
+  it('is present in the DOM', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden>Screen reader text</ts-visually-hidden>',
+    });
+
+    expect(page.root).toBeDefined();
+    expect(page.root?.textContent).toBe('Screen reader text');
+  });
+
+  it('does not have focusable class by default', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden>Hidden text</ts-visually-hidden>',
+    });
+
+    expect(page.root).not.toHaveAttribute('focusable');
+    expect(page.root?.classList.contains('focusable')).toBe(false);
+  });
+
+  it('applies focusable class when focusable prop is set', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden focusable>Skip to content</ts-visually-hidden>',
+    });
+
+    expect(page.root).toHaveAttribute('focusable');
+    expect(page.root?.classList.contains('focusable')).toBe(true);
+  });
+
+  it('reflects focusable prop to host attribute', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden focusable>Skip link</ts-visually-hidden>',
+    });
+
+    expect(page.root?.getAttribute('focusable')).not.toBeNull();
+  });
+
+  it('renders slot content inside a span', async () => {
+    const page = await newSpecPage({
+      components: [TsVisuallyHidden],
+      html: '<ts-visually-hidden>Accessible label</ts-visually-hidden>',
+    });
+
+    const span = page.root?.shadowRoot?.querySelector('span');
+    expect(span).not.toBeNull();
+    const slot = span?.querySelector('slot');
+    expect(slot).not.toBeNull();
+  });
+});

--- a/src/components/visually-hidden/visually-hidden.stories.ts
+++ b/src/components/visually-hidden/visually-hidden.stories.ts
@@ -1,0 +1,105 @@
+// Hand-written stories for ts-visually-hidden
+
+export default {
+  title: 'Utilities/Visually Hidden',
+  tags: ['autodocs'],
+  argTypes: {
+    focusable: {
+      control: 'boolean',
+      description: 'When true, the content becomes visible when focused (useful for skip links).',
+    },
+    slotContent: {
+      control: 'text',
+      description: 'The hidden content (visible to screen readers).',
+    },
+  },
+};
+
+const Template = (args: Record<string, unknown>): string => {
+  const attrs: string[] = [];
+  if (args.focusable) attrs.push('focusable');
+  return `
+    <div>
+      <p style="color: var(--ts-color-text-secondary); margin-bottom: var(--ts-spacing-2);">
+        The text below is visually hidden but readable by screen readers.
+        Inspect the DOM to see the content.
+      </p>
+      <ts-visually-hidden ${attrs.join(' ')}>${args.slotContent || 'This text is only for screen readers'}</ts-visually-hidden>
+    </div>
+  `;
+};
+
+export const Default = Object.assign(Template.bind({}) as typeof Template & { args: Record<string, unknown> }, {
+  args: {
+    focusable: false,
+    slotContent: 'This text is only for screen readers',
+  },
+});
+
+export const WithFocusableSkipLink = (): string => `
+  <div>
+    <p style="color: var(--ts-color-text-secondary); margin-bottom: var(--ts-spacing-2);">
+      Press <strong>Tab</strong> to reveal the skip link below:
+    </p>
+    <ts-visually-hidden focusable>
+      <a href="#main-content" style="
+        display: inline-block;
+        padding: var(--ts-spacing-2) var(--ts-spacing-4);
+        background: var(--ts-color-interactive-primary);
+        color: var(--ts-color-text-on-primary);
+        text-decoration: none;
+        border-radius: var(--ts-shape-interactive);
+        font-weight: var(--ts-font-weight-medium);
+      ">Skip to main content</a>
+    </ts-visually-hidden>
+    <div id="main-content" style="margin-top: var(--ts-spacing-4); padding: var(--ts-spacing-4); border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-container);">
+      <p style="margin: 0;">Main page content goes here.</p>
+    </div>
+  </div>
+`;
+
+export const IconButtonLabel = (): string => `
+  <div>
+    <p style="color: var(--ts-color-text-secondary); margin-bottom: var(--ts-spacing-2);">
+      The buttons below use visually hidden text to provide accessible labels for icon-only buttons:
+    </p>
+    <ts-row gap="2">
+      <ts-button appearance="ghost" variant="neutral">
+        <ts-icon slot="prefix" name="search" size="sm"></ts-icon>
+        <ts-visually-hidden>Search</ts-visually-hidden>
+      </ts-button>
+      <ts-button appearance="ghost" variant="neutral">
+        <ts-icon slot="prefix" name="bell" size="sm"></ts-icon>
+        <ts-visually-hidden>Notifications</ts-visually-hidden>
+      </ts-button>
+      <ts-button appearance="ghost" variant="neutral">
+        <ts-icon slot="prefix" name="settings" size="sm"></ts-icon>
+        <ts-visually-hidden>Settings</ts-visually-hidden>
+      </ts-button>
+      <ts-button appearance="ghost" variant="danger">
+        <ts-icon slot="prefix" name="trash-2" size="sm"></ts-icon>
+        <ts-visually-hidden>Delete item</ts-visually-hidden>
+      </ts-button>
+    </ts-row>
+  </div>
+`;
+
+export const FormFieldDescription = (): string => `
+  <div style="max-width: 400px;">
+    <p style="color: var(--ts-color-text-secondary); margin-bottom: var(--ts-spacing-2);">
+      Visually hidden text provides extra context for screen readers alongside form fields:
+    </p>
+    <ts-stack gap="3">
+      <div>
+        <label for="email" style="display: block; margin-bottom: var(--ts-spacing-1); font-weight: var(--ts-font-weight-medium);">Email</label>
+        <ts-visually-hidden>Required field. Enter your work email address.</ts-visually-hidden>
+        <ts-input id="email" placeholder="you@company.com" type="email"></ts-input>
+      </div>
+      <div>
+        <label for="password" style="display: block; margin-bottom: var(--ts-spacing-1); font-weight: var(--ts-font-weight-medium);">Password</label>
+        <ts-visually-hidden>Required field. Must be at least 8 characters with one uppercase letter and one number.</ts-visually-hidden>
+        <ts-input id="password" placeholder="Enter your password" type="password"></ts-input>
+      </div>
+    </ts-stack>
+  </div>
+`;

--- a/src/components/visually-hidden/visually-hidden.tsx
+++ b/src/components/visually-hidden/visually-hidden.tsx
@@ -1,0 +1,33 @@
+import { Component, Prop, h, Host } from '@stencil/core';
+
+/**
+ * A utility component that visually hides content while keeping it
+ * accessible to screen readers. Useful for providing additional context
+ * to assistive technologies without cluttering the visual interface.
+ *
+ * @slot - Default slot for content to be visually hidden.
+ */
+@Component({
+  tag: 'ts-visually-hidden',
+  styleUrl: 'visually-hidden.css',
+  shadow: true,
+})
+export class TsVisuallyHidden {
+  /** When true, the content becomes visible when focused (useful for skip links). */
+  @Prop({ reflect: true }) focusable = false;
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    return (
+      <Host
+        class={{
+          'focusable': this.focusable,
+        }}
+      >
+        <span>
+          <slot />
+        </span>
+      </Host>
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,3 +68,4 @@ export { TsContainer } from './components/container/container';
 export { TsStack } from './components/stack/stack';
 export { TsRow } from './components/row/row';
 export { TsSpacer } from './components/spacer/spacer';
+export { TsVisuallyHidden } from './components/visually-hidden/visually-hidden';


### PR DESCRIPTION
## Summary
- New `<ts-visually-hidden>` component for accessible screen-reader-only content
- Optional `focusable` prop for skip links (becomes visible on focus)
- 6 unit tests, 4 e2e tests, hand-written stories
- Updated `.ai-instructions.md` with new component in directory structure

Closes #57

## Test plan
- [x] Unit tests pass (`pnpm test -- --spec src/components/visually-hidden/visually-hidden.spec.ts`)
- [x] Build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)