### PR TITLE
feat(input): add clearable prop and character counter

### DIFF
--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -153,3 +153,47 @@
   color: var(--ts-color-danger-600);
   font-weight: var(--ts-font-weight-medium);
 }
+
+/* ---- Clear Button ---- */
+.input__clear-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: var(--ts-spacing-1);
+  color: var(--ts-color-text-tertiary);
+  border-radius: var(--ts-radius-sm);
+  transition:
+    color var(--ts-transition-fast),
+    background-color var(--ts-transition-fast);
+  flex-shrink: 0;
+}
+
+.input__clear-button:hover {
+  color: var(--ts-color-text-primary);
+  background-color: var(--ts-color-neutral-100);
+}
+
+.input__clear-button:focus-visible {
+  outline: 2px solid var(--ts-color-primary-500);
+  outline-offset: -2px;
+}
+
+/* ---- Character Counter ---- */
+.input__counter {
+  margin-block-start: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  line-height: var(--ts-line-height-normal);
+  color: var(--ts-color-text-tertiary);
+  text-align: end;
+}
+
+.input__counter--warning {
+  color: var(--ts-color-warning-500);
+}
+
+.input__counter--danger {
+  color: var(--ts-color-danger-500);
+}

--- a/src/components/input/input.e2e.ts
+++ b/src/components/input/input.e2e.ts
@@ -45,4 +45,18 @@ describe('ts-input e2e', () => {
     const disabled = await input.getProperty('disabled');
     expect(disabled).toBe(true);
   });
+
+  it('clears input value when clear button is clicked', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-input clearable value="hello"></ts-input>');
+
+    const clearBtn = await page.find('ts-input >>> .input__clear-button');
+    expect(clearBtn).not.toBeNull();
+    await clearBtn.click();
+    await page.waitForChanges();
+
+    const el = await page.find('ts-input');
+    const value = await el.getProperty('value');
+    expect(value).toBe('');
+  });
 });

--- a/src/components/input/input.spec.ts
+++ b/src/components/input/input.spec.ts
@@ -168,4 +168,87 @@ describe('ts-input', () => {
     const input = page.root?.shadowRoot?.querySelector('input');
     expect(input?.type).toBe('email');
   });
+
+  it('renders clear button when clearable and has value', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input clearable value="hello"></ts-input>',
+    });
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.input__clear-button');
+    expect(clearBtn).not.toBeNull();
+  });
+
+  it('hides clear button when value is empty', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input clearable value=""></ts-input>',
+    });
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.input__clear-button');
+    expect(clearBtn).toBeNull();
+  });
+
+  it('hides clear button when disabled', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input clearable value="hello" disabled></ts-input>',
+    });
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.input__clear-button');
+    expect(clearBtn).toBeNull();
+  });
+
+  it('clears value and emits events on clear button click', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input clearable value="hello"></ts-input>',
+    });
+
+    const inputSpy = jest.fn();
+    const changeSpy = jest.fn();
+    page.root?.addEventListener('tsInput', inputSpy);
+    page.root?.addEventListener('tsChange', changeSpy);
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.input__clear-button') as HTMLButtonElement;
+    clearBtn?.click();
+    await page.waitForChanges();
+
+    expect(page.rootInstance.value).toBe('');
+    expect(inputSpy).toHaveBeenCalledTimes(1);
+    expect(changeSpy).toHaveBeenCalledTimes(1);
+    expect(inputSpy.mock.calls[0][0].detail.previousValue).toBe('hello');
+  });
+
+  it('renders character counter when showCount and maxlength are set', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input show-count maxlength="100" value="hello"></ts-input>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.input__counter');
+    expect(counter).not.toBeNull();
+    expect(counter?.textContent).toBe('5/100');
+  });
+
+  it('applies warning color near limit', async () => {
+    // 19/20 = 0.95, which is > 0.9 and < 1
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input show-count maxlength="20" value="1234567890123456789"></ts-input>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.input__counter');
+    expect(counter?.classList.contains('input__counter--warning')).toBe(true);
+  });
+
+  it('applies danger color at limit', async () => {
+    const page = await newSpecPage({
+      components: [TsInput],
+      html: '<ts-input show-count maxlength="5" value="12345"></ts-input>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.input__counter');
+    expect(counter?.classList.contains('input__counter--danger')).toBe(true);
+  });
 });

--- a/src/components/input/input.stories.ts
+++ b/src/components/input/input.stories.ts
@@ -23,6 +23,8 @@ export default {
     disabled: { control: 'boolean', description: 'Renders the input as disabled.' },
     readonly: { control: 'boolean', description: 'Renders the input as readonly.' },
     maxlength: { control: 'number', description: 'Maximum character length.' },
+    clearable: { control: 'boolean', description: 'Shows a clear button when the input has a value.' },
+    showCount: { control: 'boolean', description: 'Shows a character counter when maxlength is set.' },
     name: { control: 'text', description: 'Name attribute for form submission.' },
   },
 };
@@ -40,6 +42,8 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.disabled) attrs.push('disabled');
   if (args.readonly) attrs.push('readonly');
   if (args.maxlength !== undefined && args.maxlength !== null) attrs.push(`maxlength="${args.maxlength}"`);
+  if (args.clearable) attrs.push('clearable');
+  if (args.showCount) attrs.push('show-count');
   if (args.name !== undefined && args.name !== null && args.name !== '') attrs.push(`name="${args.name}"`);
   return `<div style="max-width: 400px;"><ts-input ${attrs.join(' ')}></ts-input></div>`;
 };
@@ -111,6 +115,24 @@ export const WithIcons = (): string => `
       <ts-icon slot="prefix" name="lock" size="sm"></ts-icon>
       <ts-icon slot="suffix" name="eye" size="sm"></ts-icon>
     </ts-input>
+  </ts-stack>
+`;
+
+export const Clearable = (): string => `
+  <ts-stack gap="3" style="max-width: 400px;">
+    <ts-input label="Search" type="search" placeholder="Search files..." value="quarterly-report.pdf" clearable>
+      <ts-icon slot="prefix" name="search" size="sm"></ts-icon>
+    </ts-input>
+    <ts-input label="Username" placeholder="Enter username" value="johndoe" clearable></ts-input>
+    <ts-input label="Disabled (not clearable)" value="locked value" clearable disabled></ts-input>
+  </ts-stack>
+`;
+
+export const CharacterCounter = (): string => `
+  <ts-stack gap="3" style="max-width: 400px;">
+    <ts-input label="Username" placeholder="Choose a username" maxlength="20" value="john" show-count help-text="Must be unique."></ts-input>
+    <ts-input label="Near Limit" maxlength="10" value="123456789" show-count></ts-input>
+    <ts-input label="At Limit" maxlength="5" value="12345" show-count></ts-input>
   </ts-stack>
 `;
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -23,8 +23,10 @@ import { generateId } from '../../utils/aria';
  * @part input - The native input element.
  * @part prefix - The prefix slot wrapper.
  * @part suffix - The suffix slot wrapper.
+ * @part clear-button - The clear button element.
  * @part help-text - The help text wrapper.
  * @part error-text - The error message wrapper.
+ * @part counter - The character counter element.
  */
 @Component({
   tag: 'ts-input',
@@ -83,6 +85,12 @@ export class TsInput {
 
   /** Pattern for validation (regex string). */
   @Prop() pattern?: string;
+
+  /** Shows a clear button when the input has a value. */
+  @Prop({ reflect: true }) clearable = false;
+
+  /** Shows a character counter when maxlength is set. */
+  @Prop({ reflect: true }) showCount = false;
 
   /** Autocomplete attribute. */
   @Prop() autocomplete?: string;
@@ -157,12 +165,24 @@ export class TsInput {
     this.tsBlur.emit();
   };
 
+  private handleClear = (event: Event): void => {
+    event.preventDefault();
+    event.stopPropagation();
+    const previousValue = this.value;
+    this.value = '';
+    this.tsInput.emit({ value: '', previousValue });
+    this.tsChange.emit({ value: '', previousValue });
+    this.inputEl?.focus();
+  };
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
     const hasError = !!this.error;
     const labelId = `${this.inputId}-label`;
     const helpId = `${this.inputId}-help`;
     const errorId = `${this.inputId}-error`;
+    const showClear = this.clearable && this.value.length > 0 && !this.disabled && !this.readonly;
+    const showCounter = this.showCount && this.maxlength !== undefined && this.maxlength > 0;
 
     return (
       <Host
@@ -220,6 +240,21 @@ export class TsInput {
             onBlur={this.handleBlur}
           />
 
+          {showClear && (
+            <button
+              class="input__clear-button"
+              part="clear-button"
+              type="button"
+              aria-label="Clear input"
+              tabindex={-1}
+              onClick={this.handleClear}
+            >
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                <path d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
+              </svg>
+            </button>
+          )}
+
           <span class="input__suffix" part="suffix">
             <slot name="suffix" />
           </span>
@@ -234,6 +269,20 @@ export class TsInput {
         {!hasError && this.helpText && (
           <div class="input__help" part="help-text" id={helpId}>
             {this.helpText}
+          </div>
+        )}
+
+        {showCounter && (
+          <div
+            class={{
+              'input__counter': true,
+              'input__counter--warning': this.maxlength !== undefined && this.maxlength > 0 && this.value.length / this.maxlength > 0.9 && this.value.length / this.maxlength < 1,
+              'input__counter--danger': this.maxlength !== undefined && this.maxlength > 0 && this.value.length / this.maxlength >= 1,
+            }}
+            part="counter"
+            aria-live="polite"
+          >
+            {this.value.length}/{this.maxlength}
           </div>
         )}
       </Host>


### PR DESCRIPTION
## Summary
- Add `clearable` prop that shows a clear button (×) when the input has a value, resets on click
- Add `showCount` prop that displays a character counter (e.g. "5/100") when `maxlength` is set
- Counter changes color to warning (>90%) and danger (100%) near the limit
- New CSS parts: `clear-button`, `counter`

## Test plan
- [x] Unit tests for clear button rendering, hiding when empty/disabled, click event emission
- [x] Unit tests for counter rendering, format, warning/danger color classes
- [x] E2E test for clear button click behavior
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)