### PR TITLE
feat(textarea): add character counter and auto-grow mode

### DIFF
--- a/src/components/textarea/textarea.css
+++ b/src/components/textarea/textarea.css
@@ -144,3 +144,26 @@
   color: var(--ts-color-danger-600);
   font-weight: var(--ts-font-weight-medium);
 }
+
+/* ---- Auto-grow ---- */
+:host([auto-grow]) .textarea__native {
+  resize: none;
+  overflow-y: hidden;
+}
+
+/* ---- Character Counter ---- */
+.textarea__counter {
+  margin-block-start: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  line-height: var(--ts-line-height-normal);
+  color: var(--ts-color-text-tertiary);
+  text-align: end;
+}
+
+.textarea__counter--warning {
+  color: var(--ts-color-warning-500);
+}
+
+.textarea__counter--danger {
+  color: var(--ts-color-danger-500);
+}

--- a/src/components/textarea/textarea.spec.ts
+++ b/src/components/textarea/textarea.spec.ts
@@ -110,4 +110,54 @@ describe('ts-textarea', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('renders character counter when showCount and maxlength are set', async () => {
+    const page = await newSpecPage({
+      components: [TsTextarea],
+      html: '<ts-textarea show-count maxlength="500" value="hello"></ts-textarea>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.textarea__counter');
+    expect(counter).not.toBeNull();
+    expect(counter?.textContent).toBe('5/500');
+  });
+
+  it('hides counter when showCount is false', async () => {
+    const page = await newSpecPage({
+      components: [TsTextarea],
+      html: '<ts-textarea maxlength="500" value="hello"></ts-textarea>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.textarea__counter');
+    expect(counter).toBeNull();
+  });
+
+  it('applies warning color on counter near limit', async () => {
+    const page = await newSpecPage({
+      components: [TsTextarea],
+      html: '<ts-textarea show-count maxlength="20" value="1234567890123456789"></ts-textarea>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.textarea__counter');
+    expect(counter?.classList.contains('textarea__counter--warning')).toBe(true);
+  });
+
+  it('applies danger color on counter at limit', async () => {
+    const page = await newSpecPage({
+      components: [TsTextarea],
+      html: '<ts-textarea show-count maxlength="5" value="12345"></ts-textarea>',
+    });
+
+    const counter = page.root?.shadowRoot?.querySelector('.textarea__counter');
+    expect(counter?.classList.contains('textarea__counter--danger')).toBe(true);
+  });
+
+  it('applies auto-grow class when autoGrow is true', async () => {
+    const page = await newSpecPage({
+      components: [TsTextarea],
+      html: '<ts-textarea auto-grow></ts-textarea>',
+    });
+
+    expect(page.root).toHaveClass('ts-textarea--auto-grow');
+  });
 });

--- a/src/components/textarea/textarea.stories.ts
+++ b/src/components/textarea/textarea.stories.ts
@@ -25,6 +25,9 @@ export default {
       description: 'Resize behavior.',
     },
     maxlength: { control: 'number', description: 'Maximum character length.' },
+    showCount: { control: 'boolean', description: 'Shows a character counter when maxlength is set.' },
+    autoGrow: { control: 'boolean', description: 'Whether the textarea auto-grows vertically.' },
+    maxHeight: { control: 'text', description: 'Maximum height for auto-grow mode (e.g., "300px").' },
     name: { control: 'text', description: 'Name attribute for form submission.' },
   },
 };
@@ -44,6 +47,9 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.rows !== undefined && args.rows !== null) attrs.push(`rows="${args.rows}"`);
   if (args.resize !== undefined && args.resize !== null) attrs.push(`resize="${args.resize}"`);
   if (args.maxlength !== undefined && args.maxlength !== null) attrs.push(`maxlength="${args.maxlength}"`);
+  if (args.showCount) attrs.push('show-count');
+  if (args.autoGrow) attrs.push('auto-grow');
+  if (args.maxHeight !== undefined && args.maxHeight !== null && args.maxHeight !== '') attrs.push(`max-height="${args.maxHeight}"`);
   if (args.name !== undefined && args.name !== null) attrs.push(`name="${args.name}"`);
   return `<ts-textarea ${attrs.join(' ')}></ts-textarea>`;
 };
@@ -91,6 +97,22 @@ export const ResizeBehaviors = (): string => `
     <ts-textarea label="Horizontal resize" resize="horizontal" placeholder="Drag horizontally..."></ts-textarea>
     <ts-textarea label="Both directions" resize="both" placeholder="Drag in any direction..."></ts-textarea>
     <ts-textarea label="No resize" resize="none" placeholder="This textarea cannot be resized."></ts-textarea>
+  </div>
+`;
+
+export const CharacterCounter = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px; max-width: 480px;">
+    <ts-textarea label="Bio" placeholder="Tell us about yourself..." maxlength="200" show-count value="Software engineer who loves building UI components."></ts-textarea>
+    <ts-textarea label="Near Limit" maxlength="20" show-count value="1234567890123456789"></ts-textarea>
+    <ts-textarea label="At Limit" maxlength="10" show-count value="1234567890"></ts-textarea>
+  </div>
+`;
+
+export const AutoGrow = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px; max-width: 480px;">
+    <ts-textarea label="Auto-growing textarea" placeholder="Start typing and watch the textarea grow..." auto-grow></ts-textarea>
+    <ts-textarea label="Auto-grow with max height" placeholder="This textarea will grow up to 150px..." auto-grow max-height="150"></ts-textarea>
+    <ts-textarea label="Auto-grow with counter" placeholder="Type your message..." auto-grow show-count maxlength="500"></ts-textarea>
   </div>
 `;
 

--- a/src/components/textarea/textarea.tsx
+++ b/src/components/textarea/textarea.tsx
@@ -9,6 +9,7 @@ import { generateId } from '../../utils/aria';
  * @part textarea - The native textarea element.
  * @part help-text - The help text wrapper.
  * @part error-text - The error message wrapper.
+ * @part counter - The character counter element.
  */
 @Component({
   tag: 'ts-textarea',
@@ -63,6 +64,15 @@ export class TsTextarea {
   /** Maximum character length. */
   @Prop() maxlength?: number;
 
+  /** Whether to show the character counter. Requires maxlength to be set. */
+  @Prop({ reflect: true }) showCount = false;
+
+  /** Whether the textarea auto-grows vertically as content is typed. */
+  @Prop({ reflect: true }) autoGrow = false;
+
+  /** Maximum height for auto-grow mode (e.g., "300px"). */
+  @Prop() maxHeight?: string;
+
   /** Whether the textarea is currently focused. */
   @State() hasFocus = false;
 
@@ -82,6 +92,15 @@ export class TsTextarea {
   handleValueChange(newValue: string, oldValue: string): void {
     if (newValue !== oldValue && this.textareaEl) {
       this.textareaEl.value = newValue;
+      if (this.autoGrow) {
+        this.adjustHeight();
+      }
+    }
+  }
+
+  componentDidLoad(): void {
+    if (this.autoGrow) {
+      this.adjustHeight();
     }
   }
 
@@ -97,11 +116,31 @@ export class TsTextarea {
     this.textareaEl?.select();
   }
 
+  private adjustHeight(): void {
+    const el = this.textareaEl;
+    if (!el) return;
+    el.style.height = 'auto';
+    let newHeight = el.scrollHeight;
+    if (this.maxHeight) {
+      const max = parseInt(this.maxHeight, 10);
+      if (!isNaN(max) && newHeight > max) {
+        newHeight = max;
+        el.style.overflowY = 'auto';
+      } else {
+        el.style.overflowY = 'hidden';
+      }
+    }
+    el.style.height = `${newHeight}px`;
+  }
+
   private handleInput = (event: Event): void => {
     const target = event.target as HTMLTextAreaElement;
     const previousValue = this.value;
     this.value = target.value;
     this.tsInput.emit({ value: this.value, previousValue });
+    if (this.autoGrow) {
+      this.adjustHeight();
+    }
   };
 
   private handleChange = (): void => {
@@ -124,6 +163,7 @@ export class TsTextarea {
     const labelId = `${this.inputId}-label`;
     const helpId = `${this.inputId}-help`;
     const errorId = `${this.inputId}-error`;
+    const showCounter = this.showCount && this.maxlength !== undefined && this.maxlength > 0;
 
     return (
       <Host
@@ -133,6 +173,7 @@ export class TsTextarea {
           'ts-textarea--focused': this.hasFocus,
           'ts-textarea--disabled': this.disabled,
           'ts-textarea--error': this.error,
+          'ts-textarea--auto-grow': this.autoGrow,
         }}
       >
         {this.label && (
@@ -184,6 +225,20 @@ export class TsTextarea {
         {!hasError && this.helpText && (
           <div class="textarea__help" part="help-text" id={helpId}>
             {this.helpText}
+          </div>
+        )}
+
+        {showCounter && (
+          <div
+            class={{
+              'textarea__counter': true,
+              'textarea__counter--warning': this.maxlength !== undefined && this.maxlength > 0 && this.value.length / this.maxlength > 0.9 && this.value.length / this.maxlength < 1,
+              'textarea__counter--danger': this.maxlength !== undefined && this.maxlength > 0 && this.value.length / this.maxlength >= 1,
+            }}
+            part="counter"
+            aria-live="polite"
+          >
+            {this.value.length}/{this.maxlength}
           </div>
         )}
       </Host>


### PR DESCRIPTION
## Summary
- Add `showCount` prop that displays a "X/Y" counter when `maxlength` is set
- Counter changes color to warning (>90%) and danger (100%) near the limit
- Add `autoGrow` prop that expands the textarea vertically as content is typed
- Add optional `maxHeight` prop to cap auto-grow expansion

## Test plan
- [x] Unit tests for counter rendering, format, warning/danger colors
- [x] Unit test for auto-grow class application
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)