### PR TITLE
feat: add RadioGroup and CheckboxGroup container components

### DIFF
--- a/src/components/checkbox-group/checkbox-group.css
+++ b/src/components/checkbox-group/checkbox-group.css
@@ -1,0 +1,39 @@
+/* ==========================================================================
+   ts-checkbox-group — Scoped Styles (no shadow DOM)
+   ========================================================================== */
+
+ts-checkbox-group {
+  display: block;
+  font-family: var(--ts-font-family-base);
+}
+
+/* ---- Label ---- */
+.checkbox-group__label {
+  display: block;
+  margin-block-end: var(--ts-spacing-2);
+  font-size: var(--ts-font-size-sm);
+  font-weight: var(--ts-font-weight-medium);
+  color: var(--ts-color-text-secondary);
+  line-height: var(--ts-line-height-normal);
+}
+
+/* ---- Items container ---- */
+.checkbox-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ts-spacing-2);
+}
+
+ts-checkbox-group[orientation="horizontal"] .checkbox-group__items {
+  flex-direction: row;
+  gap: var(--ts-spacing-4);
+}
+
+/* ---- Error ---- */
+.checkbox-group__error {
+  margin-block-start: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  line-height: var(--ts-line-height-normal);
+  color: var(--ts-color-danger-600);
+  font-weight: var(--ts-font-weight-medium);
+}

--- a/src/components/checkbox-group/checkbox-group.e2e.ts
+++ b/src/components/checkbox-group/checkbox-group.e2e.ts
@@ -1,0 +1,34 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-checkbox-group e2e', () => {
+  it('renders and hydrates', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-checkbox-group label="Interests">
+        <ts-checkbox value="music">Music</ts-checkbox>
+        <ts-checkbox value="sports">Sports</ts-checkbox>
+      </ts-checkbox-group>
+    `);
+
+    const element = await page.find('ts-checkbox-group');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('updates group value when checkboxes are toggled', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-checkbox-group label="Pick any">
+        <ts-checkbox value="a">A</ts-checkbox>
+        <ts-checkbox value="b">B</ts-checkbox>
+      </ts-checkbox-group>
+    `);
+
+    const checkboxA = await page.find('ts-checkbox[value="a"] >>> .checkbox__base');
+    await checkboxA.click();
+    await page.waitForChanges();
+
+    const group = await page.find('ts-checkbox-group');
+    const value = await group.getProperty('value');
+    expect(value).toContain('a');
+  });
+});

--- a/src/components/checkbox-group/checkbox-group.spec.ts
+++ b/src/components/checkbox-group/checkbox-group.spec.ts
@@ -1,0 +1,71 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsCheckboxGroup } from './checkbox-group';
+
+describe('ts-checkbox-group', () => {
+  it('renders with role="group"', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    const group = page.root?.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+  });
+
+  it('sets aria-label from label prop', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group label="Interests"><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    const group = page.root?.querySelector('[role="group"]');
+    expect(group?.getAttribute('aria-label')).toBe('Interests');
+  });
+
+  it('renders label text', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group label="Options"><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    const label = page.root?.querySelector('.checkbox-group__label');
+    expect(label?.textContent).toBe('Options');
+  });
+
+  it('renders vertical layout by default', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-checkbox-group--vertical');
+  });
+
+  it('renders horizontal layout', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group orientation="horizontal"><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-checkbox-group--horizontal');
+  });
+
+  it('displays error message', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group error="Select at least one"><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    const error = page.root?.querySelector('.checkbox-group__error');
+    expect(error?.textContent).toBe('Select at least one');
+  });
+
+  it('renders disabled class', async () => {
+    const page = await newSpecPage({
+      components: [TsCheckboxGroup],
+      html: '<ts-checkbox-group disabled><ts-checkbox value="a">A</ts-checkbox></ts-checkbox-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-checkbox-group--disabled');
+  });
+});

--- a/src/components/checkbox-group/checkbox-group.stories.ts
+++ b/src/components/checkbox-group/checkbox-group.stories.ts
@@ -1,0 +1,1 @@
+// Stories for this component are in the checkbox component's stories file

--- a/src/components/checkbox-group/checkbox-group.tsx
+++ b/src/components/checkbox-group/checkbox-group.tsx
@@ -1,0 +1,122 @@
+import { Component, Prop, Event, Listen, h, Host, Element } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
+import type { TsOrientation } from '../../types';
+import { generateId } from '../../utils/aria';
+
+/**
+ * @slot - Checkboxes to group.
+ *
+ * @part group - The group container.
+ * @part label - The group label.
+ * @part error-text - The error message wrapper.
+ */
+@Component({
+  tag: 'ts-checkbox-group',
+  styleUrl: 'checkbox-group.css',
+  shadow: false,
+})
+export class TsCheckboxGroup {
+  @Element() hostEl!: HTMLElement;
+
+  private groupId = generateId('ts-checkbox-group');
+
+  /** The currently checked values. */
+  @Prop({ mutable: true }) value: string[] = [];
+
+  /** Accessible label for the group. */
+  @Prop() label?: string;
+
+  /** Layout direction of the checkboxes. */
+  @Prop({ reflect: true }) orientation: TsOrientation = 'vertical';
+
+  /** Error message displayed below the group. */
+  @Prop() error?: string;
+
+  /** Disables all child checkboxes. */
+  @Prop({ reflect: true }) disabled = false;
+
+  /** Size for all child checkboxes. */
+  @Prop({ reflect: true }) size: 'sm' | 'md' | 'lg' = 'md';
+
+  /** Emitted when the selected values change. */
+  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string[] }>;
+
+  @Listen('tsChange')
+  handleChildChange(event: CustomEvent<{ checked: boolean; value: string }>): void {
+    const target = event.target as HTMLElement;
+    if (target === this.hostEl) return;
+
+    event.stopPropagation();
+
+    const { checked, value: childValue } = event.detail;
+
+    if (checked) {
+      if (!this.value.includes(childValue)) {
+        this.value = [...this.value, childValue];
+      }
+    } else {
+      this.value = this.value.filter((v) => v !== childValue);
+    }
+
+    this.tsChange.emit({ value: this.value });
+  }
+
+  componentDidLoad(): void {
+    this.syncCheckboxes();
+  }
+
+  componentDidUpdate(): void {
+    this.syncCheckboxes();
+  }
+
+  private syncCheckboxes(): void {
+    const checkboxes = this.hostEl.querySelectorAll('ts-checkbox');
+    checkboxes.forEach((checkbox: Element) => {
+      const checkboxEl = checkbox as HTMLElement & { checked?: boolean; disabled?: boolean; size?: string };
+      checkboxEl.checked = this.value.includes(checkboxEl.getAttribute('value') || '');
+      if (this.disabled) {
+        checkboxEl.disabled = true;
+      }
+      if (this.size) {
+        checkboxEl.size = this.size;
+      }
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    const hasError = !!this.error;
+    const errorId = `${this.groupId}-error`;
+
+    return (
+      <Host
+        class={{
+          'ts-checkbox-group': true,
+          [`ts-checkbox-group--${this.orientation}`]: true,
+          'ts-checkbox-group--disabled': this.disabled,
+          'ts-checkbox-group--error': hasError,
+        }}
+      >
+        {this.label && (
+          <div class="checkbox-group__label" part="label" id={`${this.groupId}-label`}>
+            {this.label}
+          </div>
+        )}
+        <div
+          class="checkbox-group__items"
+          part="group"
+          role="group"
+          aria-label={this.label || undefined}
+          aria-describedby={hasError ? errorId : undefined}
+        >
+          <slot />
+        </div>
+        {hasError && (
+          <div class="checkbox-group__error" part="error-text" id={errorId} role="alert">
+            {this.error}
+          </div>
+        )}
+      </Host>
+    );
+  }
+}

--- a/src/components/checkbox/checkbox.stories.ts
+++ b/src/components/checkbox/checkbox.stories.ts
@@ -86,3 +86,36 @@ export const WithSlotContent = (): string => `
     </ts-checkbox>
   </ts-stack>
 `;
+
+export const CheckboxGroupDefault = (): string => `
+  <ts-checkbox-group label="Notification Preferences" style="max-width: 400px;">
+    <ts-checkbox value="email">Email notifications</ts-checkbox>
+    <ts-checkbox value="sms">SMS notifications</ts-checkbox>
+    <ts-checkbox value="push">Push notifications</ts-checkbox>
+  </ts-checkbox-group>
+`;
+
+export const CheckboxGroupHorizontal = (): string => `
+  <ts-checkbox-group label="Interests" orientation="horizontal" style="max-width: 500px;">
+    <ts-checkbox value="music">Music</ts-checkbox>
+    <ts-checkbox value="sports">Sports</ts-checkbox>
+    <ts-checkbox value="travel">Travel</ts-checkbox>
+    <ts-checkbox value="food">Food</ts-checkbox>
+  </ts-checkbox-group>
+`;
+
+export const CheckboxGroupDisabled = (): string => `
+  <ts-checkbox-group label="Features" disabled style="max-width: 400px;">
+    <ts-checkbox value="dark-mode">Dark mode</ts-checkbox>
+    <ts-checkbox value="notifications">Notifications</ts-checkbox>
+    <ts-checkbox value="analytics">Analytics</ts-checkbox>
+  </ts-checkbox-group>
+`;
+
+export const CheckboxGroupError = (): string => `
+  <ts-checkbox-group label="Required Skills" error="Please select at least one skill" style="max-width: 400px;">
+    <ts-checkbox value="js">JavaScript</ts-checkbox>
+    <ts-checkbox value="ts">TypeScript</ts-checkbox>
+    <ts-checkbox value="react">React</ts-checkbox>
+  </ts-checkbox-group>
+`;

--- a/src/components/radio-group/radio-group.css
+++ b/src/components/radio-group/radio-group.css
@@ -1,0 +1,39 @@
+/* ==========================================================================
+   ts-radio-group — Scoped Styles (no shadow DOM)
+   ========================================================================== */
+
+ts-radio-group {
+  display: block;
+  font-family: var(--ts-font-family-base);
+}
+
+/* ---- Label ---- */
+.radio-group__label {
+  display: block;
+  margin-block-end: var(--ts-spacing-2);
+  font-size: var(--ts-font-size-sm);
+  font-weight: var(--ts-font-weight-medium);
+  color: var(--ts-color-text-secondary);
+  line-height: var(--ts-line-height-normal);
+}
+
+/* ---- Items container ---- */
+.radio-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ts-spacing-2);
+}
+
+ts-radio-group[orientation="horizontal"] .radio-group__items {
+  flex-direction: row;
+  gap: var(--ts-spacing-4);
+}
+
+/* ---- Error ---- */
+.radio-group__error {
+  margin-block-start: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  line-height: var(--ts-line-height-normal);
+  color: var(--ts-color-danger-600);
+  font-weight: var(--ts-font-weight-medium);
+}

--- a/src/components/radio-group/radio-group.e2e.ts
+++ b/src/components/radio-group/radio-group.e2e.ts
@@ -1,0 +1,34 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-radio-group e2e', () => {
+  it('renders and hydrates', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-radio-group label="Favorite color">
+        <ts-radio value="red">Red</ts-radio>
+        <ts-radio value="blue">Blue</ts-radio>
+      </ts-radio-group>
+    `);
+
+    const element = await page.find('ts-radio-group');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('updates group value when a radio is selected', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-radio-group label="Pick one">
+        <ts-radio value="a">A</ts-radio>
+        <ts-radio value="b">B</ts-radio>
+      </ts-radio-group>
+    `);
+
+    const radioB = await page.find('ts-radio[value="b"] >>> .radio__base');
+    await radioB.click();
+    await page.waitForChanges();
+
+    const group = await page.find('ts-radio-group');
+    const value = await group.getProperty('value');
+    expect(value).toBe('b');
+  });
+});

--- a/src/components/radio-group/radio-group.spec.ts
+++ b/src/components/radio-group/radio-group.spec.ts
@@ -1,0 +1,71 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsRadioGroup } from './radio-group';
+
+describe('ts-radio-group', () => {
+  it('renders with role="radiogroup"', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    const group = page.root?.querySelector('[role="radiogroup"]');
+    expect(group).not.toBeNull();
+  });
+
+  it('sets aria-label from label prop', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group label="Pick one"><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    const group = page.root?.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('aria-label')).toBe('Pick one');
+  });
+
+  it('renders label text', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group label="Options"><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    const label = page.root?.querySelector('.radio-group__label');
+    expect(label?.textContent).toBe('Options');
+  });
+
+  it('renders vertical layout by default', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-radio-group--vertical');
+  });
+
+  it('renders horizontal layout', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group orientation="horizontal"><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-radio-group--horizontal');
+  });
+
+  it('displays error message', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group error="Please select an option"><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    const error = page.root?.querySelector('.radio-group__error');
+    expect(error?.textContent).toBe('Please select an option');
+  });
+
+  it('renders disabled class', async () => {
+    const page = await newSpecPage({
+      components: [TsRadioGroup],
+      html: '<ts-radio-group disabled><ts-radio value="a">A</ts-radio></ts-radio-group>',
+    });
+
+    expect(page.root).toHaveClass('ts-radio-group--disabled');
+  });
+});

--- a/src/components/radio-group/radio-group.stories.ts
+++ b/src/components/radio-group/radio-group.stories.ts
@@ -1,0 +1,1 @@
+// Stories for this component are in the radio component's stories file

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -1,0 +1,123 @@
+import { Component, Prop, Event, Listen, h, Host, Element } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
+import type { TsOrientation } from '../../types';
+import { generateId } from '../../utils/aria';
+
+/**
+ * @slot - Radio buttons to group.
+ *
+ * @part group - The group container.
+ * @part label - The group label.
+ * @part error-text - The error message wrapper.
+ */
+@Component({
+  tag: 'ts-radio-group',
+  styleUrl: 'radio-group.css',
+  shadow: false,
+})
+export class TsRadioGroup {
+  @Element() hostEl!: HTMLElement;
+
+  private groupId = generateId('ts-radio-group');
+
+  /** The currently selected value. */
+  @Prop({ mutable: true, reflect: true }) value?: string;
+
+  /** Shared name for all child radios. */
+  @Prop() name?: string;
+
+  /** Accessible label for the group. */
+  @Prop() label?: string;
+
+  /** Layout direction of the radios. */
+  @Prop({ reflect: true }) orientation: TsOrientation = 'vertical';
+
+  /** Error message displayed below the group. */
+  @Prop() error?: string;
+
+  /** Disables all child radios. */
+  @Prop({ reflect: true }) disabled = false;
+
+  /** Size for all child radios. */
+  @Prop({ reflect: true }) size: 'sm' | 'md' | 'lg' = 'md';
+
+  /** Emitted when the selected value changes. */
+  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string }>;
+
+  @Listen('tsChange')
+  handleChildChange(event: CustomEvent<{ checked: boolean; value: string }>): void {
+    // Only handle events from child ts-radio, not our own
+    const target = event.target as HTMLElement;
+    if (target === this.hostEl) return;
+
+    event.stopPropagation();
+
+    if (event.detail.checked) {
+      this.value = event.detail.value;
+      this.syncRadios();
+      this.tsChange.emit({ value: this.value });
+    }
+  }
+
+  componentDidLoad(): void {
+    this.syncRadios();
+  }
+
+  componentDidUpdate(): void {
+    this.syncRadios();
+  }
+
+  private syncRadios(): void {
+    const radios = this.hostEl.querySelectorAll('ts-radio');
+    radios.forEach((radio: Element) => {
+      const radioEl = radio as HTMLElement & { name?: string; checked?: boolean; disabled?: boolean; size?: string };
+      if (this.name) {
+        radioEl.name = this.name;
+      }
+      radioEl.checked = radioEl.getAttribute('value') === this.value;
+      if (this.disabled) {
+        radioEl.disabled = true;
+      }
+      if (this.size) {
+        radioEl.size = this.size;
+      }
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    const hasError = !!this.error;
+    const errorId = `${this.groupId}-error`;
+
+    return (
+      <Host
+        class={{
+          'ts-radio-group': true,
+          [`ts-radio-group--${this.orientation}`]: true,
+          'ts-radio-group--disabled': this.disabled,
+          'ts-radio-group--error': hasError,
+        }}
+      >
+        {this.label && (
+          <div class="radio-group__label" part="label" id={`${this.groupId}-label`}>
+            {this.label}
+          </div>
+        )}
+        <div
+          class="radio-group__items"
+          part="group"
+          role="radiogroup"
+          aria-label={this.label || undefined}
+          aria-describedby={hasError ? errorId : undefined}
+        >
+          <slot />
+        </div>
+        {hasError && (
+          <div class="radio-group__error" part="error-text" id={errorId} role="alert">
+            {this.error}
+          </div>
+        )}
+      </Host>
+    );
+  }
+}

--- a/src/components/radio/radio.stories.ts
+++ b/src/components/radio/radio.stories.ts
@@ -75,3 +75,35 @@ export const PaymentMethod = (): string => `
     <ts-radio name="payment" value="bank" label="Bank transfer"></ts-radio>
   </ts-stack>
 `;
+
+export const RadioGroupDefault = (): string => `
+  <ts-radio-group label="Shipping Method" name="shipping-group" value="standard" style="max-width: 400px;">
+    <ts-radio value="standard">Standard shipping (5-7 business days)</ts-radio>
+    <ts-radio value="express">Express shipping (2-3 business days)</ts-radio>
+    <ts-radio value="overnight">Overnight shipping (next business day)</ts-radio>
+  </ts-radio-group>
+`;
+
+export const RadioGroupHorizontal = (): string => `
+  <ts-radio-group label="Size" name="size-group" value="md" orientation="horizontal" style="max-width: 400px;">
+    <ts-radio value="sm">Small</ts-radio>
+    <ts-radio value="md">Medium</ts-radio>
+    <ts-radio value="lg">Large</ts-radio>
+  </ts-radio-group>
+`;
+
+export const RadioGroupDisabled = (): string => `
+  <ts-radio-group label="Plan" name="plan-group" value="free" disabled style="max-width: 400px;">
+    <ts-radio value="free">Free plan</ts-radio>
+    <ts-radio value="pro">Pro plan</ts-radio>
+    <ts-radio value="enterprise">Enterprise plan</ts-radio>
+  </ts-radio-group>
+`;
+
+export const RadioGroupError = (): string => `
+  <ts-radio-group label="Priority" name="priority-group" error="Please select a priority level" style="max-width: 400px;">
+    <ts-radio value="low">Low</ts-radio>
+    <ts-radio value="medium">Medium</ts-radio>
+    <ts-radio value="high">High</ts-radio>
+  </ts-radio-group>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,3 +69,5 @@ export { TsStack } from './components/stack/stack';
 export { TsRow } from './components/row/row';
 export { TsSpacer } from './components/spacer/spacer';
 export { TsVisuallyHidden } from './components/visually-hidden/visually-hidden';
+export { TsRadioGroup } from './components/radio-group/radio-group';
+export { TsCheckboxGroup } from './components/checkbox-group/checkbox-group';


### PR DESCRIPTION
## Summary
- Add `ts-radio-group` component that manages single selection across child `ts-radio` elements
- Add `ts-checkbox-group` component that manages multiple selection across child `ts-checkbox` elements
- Both support: `label`, `orientation` (vertical/horizontal), `error`, `disabled`, `size` props
- Light DOM slots with event delegation for child change events

## Test plan
- [x] 7 unit tests for RadioGroup (role, aria-label, label, layouts, error, disabled)
- [x] 7 unit tests for CheckboxGroup (role, aria-label, label, layouts, error, disabled)
- [x] E2E tests for hydration and value updates
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)