### PR TITLE
feat(slider): add range mode, marks, and vertical orientation

### DIFF
--- a/src/components/slider/slider.css
+++ b/src/components/slider/slider.css
@@ -79,6 +79,7 @@
   transition:
     box-shadow var(--ts-transition-fast),
     transform var(--ts-transition-fast);
+  z-index: 1;
 }
 
 .slider__thumb:focus-visible {
@@ -120,4 +121,89 @@
 
 :host(.ts-slider--disabled) .slider__thumb {
   cursor: not-allowed;
+}
+
+/* ---- Marks ---- */
+.slider__marks {
+  position: absolute;
+  inset-inline: 0;
+  inset-block: 0;
+  pointer-events: none;
+}
+
+.slider__mark {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transform: translateX(-50%);
+}
+
+.slider__mark-tick {
+  inline-size: 4px;
+  block-size: 4px;
+  border-radius: var(--ts-radius-full);
+  background-color: var(--ts-slider-track-bg);
+  margin-block-start: calc((var(--ts-slider-thumb-size) - 4px) / 2);
+}
+
+.slider__mark-label {
+  font-family: var(--ts-font-family-base);
+  font-size: var(--ts-font-size-xs);
+  color: var(--ts-color-text-tertiary);
+  margin-block-start: calc(var(--ts-slider-thumb-size) / 2 + var(--ts-spacing-1));
+  white-space: nowrap;
+}
+
+/* ---- Vertical Orientation ---- */
+:host([orientation="vertical"]) {
+  display: inline-flex;
+  block-size: 200px;
+}
+
+:host([orientation="vertical"]) .slider__track {
+  flex-direction: column;
+  inline-size: var(--ts-slider-thumb-size);
+  block-size: 100%;
+}
+
+:host([orientation="vertical"]) .slider__track::before {
+  inset-inline: auto;
+  inset-block: 0;
+  inline-size: 4px;
+  block-size: auto;
+  inset-inline-start: 50%;
+  transform: translateX(-50%);
+}
+
+:host([orientation="vertical"]) .slider__fill {
+  inset-inline-start: 50%;
+  transform: translateX(-50%);
+  inline-size: 4px;
+  block-size: auto;
+  inset-block-start: auto;
+}
+
+:host([orientation="vertical"]) .slider__thumb {
+  transform: translateY(50%);
+  inset-inline-start: 0;
+}
+
+:host([orientation="vertical"]) .slider__thumb:active {
+  transform: translateY(50%) scale(1.1);
+}
+
+:host([orientation="vertical"]) .slider__mark {
+  transform: translateY(50%);
+  flex-direction: row;
+}
+
+:host([orientation="vertical"]) .slider__mark-tick {
+  margin-block-start: 0;
+  margin-inline-start: calc((var(--ts-slider-thumb-size) - 4px) / 2);
+}
+
+:host([orientation="vertical"]) .slider__mark-label {
+  margin-block-start: 0;
+  margin-inline-start: var(--ts-spacing-2);
 }

--- a/src/components/slider/slider.spec.ts
+++ b/src/components/slider/slider.spec.ts
@@ -97,4 +97,63 @@ describe('ts-slider', () => {
     const thumb = page.root?.shadowRoot?.querySelector('.slider__thumb') as HTMLElement;
     expect(thumb?.style.insetInlineStart).toBe('50%');
   });
+
+  it('renders two thumbs in range mode', async () => {
+    const page = await newSpecPage({
+      components: [TsSlider],
+      html: '<ts-slider range value-low="20" value-high="80" min="0" max="100"></ts-slider>',
+    });
+
+    const thumbs = page.root?.shadowRoot?.querySelectorAll('[role="slider"]');
+    expect(thumbs?.length).toBe(2);
+  });
+
+  it('sets ARIA attributes on range thumbs', async () => {
+    const page = await newSpecPage({
+      components: [TsSlider],
+      html: '<ts-slider range value-low="25" value-high="75" min="0" max="100" label="Price"></ts-slider>',
+    });
+
+    const thumbLow = page.root?.shadowRoot?.querySelector('.slider__thumb--low');
+    expect(thumbLow?.getAttribute('aria-valuenow')).toBe('25');
+    expect(thumbLow?.getAttribute('aria-label')).toBe('Price minimum');
+
+    const thumbHigh = page.root?.shadowRoot?.querySelector('.slider__thumb--high');
+    expect(thumbHigh?.getAttribute('aria-valuenow')).toBe('75');
+    expect(thumbHigh?.getAttribute('aria-label')).toBe('Price maximum');
+  });
+
+  it('renders fill between thumbs in range mode', async () => {
+    const page = await newSpecPage({
+      components: [TsSlider],
+      html: '<ts-slider range value-low="20" value-high="80" min="0" max="100"></ts-slider>',
+    });
+
+    const fill = page.root?.shadowRoot?.querySelector('.slider__fill') as HTMLElement;
+    expect(fill?.style.insetInlineStart).toBe('20%');
+    expect(fill?.style.width).toBe('60%');
+  });
+
+  it('renders marks at correct positions', async () => {
+    const page = await newSpecPage({
+      components: [TsSlider],
+      html: `<ts-slider marks='[{"value":0,"label":"0%"},{"value":50,"label":"50%"},{"value":100,"label":"100%"}]'></ts-slider>`,
+    });
+
+    const marks = page.root?.shadowRoot?.querySelectorAll('.slider__mark');
+    expect(marks?.length).toBe(3);
+
+    const labels = page.root?.shadowRoot?.querySelectorAll('.slider__mark-label');
+    expect(labels?.length).toBe(3);
+    expect(labels?.[1]?.textContent).toBe('50%');
+  });
+
+  it('applies vertical class', async () => {
+    const page = await newSpecPage({
+      components: [TsSlider],
+      html: '<ts-slider orientation="vertical"></ts-slider>',
+    });
+
+    expect(page.root).toHaveClass('ts-slider--vertical');
+  });
 });

--- a/src/components/slider/slider.stories.ts
+++ b/src/components/slider/slider.stories.ts
@@ -37,6 +37,15 @@ export default {
       options: ['sm', 'md', 'lg'],
       description: 'The size of the slider.',
     },
+    range: {
+      control: 'boolean',
+      description: 'Enable range mode (dual thumbs).',
+    },
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Orientation of the slider.',
+    },
   },
 };
 
@@ -78,6 +87,34 @@ export const States = (): string => `
   <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
     <ts-slider value="70" label="Volume" show-value></ts-slider>
     <ts-slider value="50" label="Disabled slider" show-value disabled></ts-slider>
+  </div>
+`;
+
+export const Range = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
+    <ts-slider range value-low="200" value-high="800" min="0" max="1000" step="50" label="Price Range ($)" show-value></ts-slider>
+    <ts-slider range value-low="18" value-high="35" min="0" max="100" label="Age Range" show-value></ts-slider>
+  </div>
+`;
+
+export const WithMarks = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 48px; max-width: 400px;">
+    <ts-slider value="50" label="Percentage" show-value marks='[{"value":0,"label":"0%"},{"value":25,"label":"25%"},{"value":50,"label":"50%"},{"value":75,"label":"75%"},{"value":100,"label":"100%"}]'></ts-slider>
+    <ts-slider value="3" min="1" max="5" step="1" label="Rating" show-value marks='[{"value":1,"label":"Poor"},{"value":2,"label":"Fair"},{"value":3,"label":"Good"},{"value":4,"label":"Great"},{"value":5,"label":"Excellent"}]'></ts-slider>
+  </div>
+`;
+
+export const Vertical = (): string => `
+  <div style="display: flex; gap: 48px; align-items: flex-end; height: 250px;">
+    <ts-slider orientation="vertical" value="75" label="Volume" show-value></ts-slider>
+    <ts-slider orientation="vertical" value="50" label="Bass" show-value></ts-slider>
+    <ts-slider orientation="vertical" value="25" label="Treble" show-value></ts-slider>
+  </div>
+`;
+
+export const RangeWithMarks = (): string => `
+  <div style="max-width: 400px; padding-bottom: 24px;">
+    <ts-slider range value-low="20" value-high="80" min="0" max="100" label="Budget Range" show-value marks='[{"value":0,"label":"$0"},{"value":25,"label":"$25k"},{"value":50,"label":"$50k"},{"value":75,"label":"$75k"},{"value":100,"label":"$100k"}]'></ts-slider>
   </div>
 `;
 

--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,12 +1,20 @@
 import { Component, Prop, Event, State, h, Host, Element } from '@stencil/core';
 import type { EventEmitter } from '@stencil/core';
-import type { TsSize } from '../../types';
+import type { TsSize, TsOrientation } from '../../types';
+
+interface SliderMark {
+  value: number;
+  label?: string;
+}
 
 /**
  * @part track - The slider track.
  * @part fill - The filled portion of the track.
- * @part thumb - The draggable thumb.
+ * @part thumb - The draggable thumb (single mode).
+ * @part thumb-low - The low thumb (range mode).
+ * @part thumb-high - The high thumb (range mode).
  * @part label - The value label.
+ * @part marks - The marks container.
  */
 @Component({
   tag: 'ts-slider',
@@ -19,9 +27,19 @@ export class TsSlider {
   private trackEl?: HTMLElement;
 
   @State() dragging = false;
+  @State() activeThumb: 'low' | 'high' | null = null;
 
-  /** Current slider value. */
+  /** Current slider value (single mode). */
   @Prop({ mutable: true, reflect: true }) value = 0;
+
+  /** Low value for range mode. */
+  @Prop({ mutable: true, reflect: true }) valueLow?: number;
+
+  /** High value for range mode. */
+  @Prop({ mutable: true, reflect: true }) valueHigh?: number;
+
+  /** Whether to use range mode (dual thumbs). */
+  @Prop({ reflect: true }) range = false;
 
   /** Minimum value. */
   @Prop() min = 0;
@@ -44,48 +62,106 @@ export class TsSlider {
   /** The size of the slider. */
   @Prop({ reflect: true }) size: TsSize = 'md';
 
+  /** Orientation of the slider. */
+  @Prop({ reflect: true }) orientation: TsOrientation = 'horizontal';
+
+  /** JSON string of marks: [{"value": 0, "label": "0%"}, ...] */
+  @Prop() marks?: string;
+
   /** Emitted continuously during drag. */
-  @Event({ eventName: 'tsInput' }) tsInput!: EventEmitter<{ value: number }>;
+  @Event({ eventName: 'tsInput' }) tsInput!: EventEmitter<{ value: number; valueLow?: number; valueHigh?: number }>;
 
   /** Emitted when drag ends (value committed). */
-  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: number }>;
+  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: number; valueLow?: number; valueHigh?: number }>;
+
+  private get effectiveLow(): number {
+    return this.valueLow !== undefined ? this.valueLow : this.min;
+  }
+
+  private get effectiveHigh(): number {
+    return this.valueHigh !== undefined ? this.valueHigh : this.max;
+  }
+
+  private get isVertical(): boolean {
+    return this.orientation === 'vertical';
+  }
+
+  private get parsedMarks(): SliderMark[] {
+    if (!this.marks) return [];
+    try {
+      return JSON.parse(this.marks);
+    } catch {
+      return [];
+    }
+  }
+
+  private toPercent(val: number): number {
+    const r = this.max - this.min;
+    if (r <= 0) return 0;
+    return ((val - this.min) / r) * 100;
+  }
 
   private get percentage(): number {
-    const range = this.max - this.min;
-    if (range <= 0) return 0;
-    return ((this.value - this.min) / range) * 100;
+    return this.toPercent(this.value);
   }
 
   private clampAndStep(val: number): number {
-    // Snap to step
     const stepped = Math.round((val - this.min) / this.step) * this.step + this.min;
-    // Clamp
     return Math.min(this.max, Math.max(this.min, stepped));
   }
 
-  private updateValueFromPosition(clientX: number): void {
-    if (!this.trackEl) return;
+  private getValueFromPosition(clientX: number, clientY: number): number {
+    if (!this.trackEl) return this.value;
     const rect = this.trackEl.getBoundingClientRect();
-    const ratio = (clientX - rect.left) / rect.width;
-    const rawValue = this.min + ratio * (this.max - this.min);
-    this.value = this.clampAndStep(rawValue);
+    let ratio: number;
+    if (this.isVertical) {
+      ratio = 1 - (clientY - rect.top) / rect.height;
+    } else {
+      ratio = (clientX - rect.left) / rect.width;
+    }
+    return this.min + ratio * (this.max - this.min);
+  }
+
+  private emitValues(): { value: number; valueLow?: number; valueHigh?: number } {
+    if (this.range) {
+      return { value: this.effectiveLow, valueLow: this.effectiveLow, valueHigh: this.effectiveHigh };
+    }
+    return { value: this.value };
   }
 
   private handleMouseDown = (event: MouseEvent): void => {
     if (this.disabled) return;
     event.preventDefault();
     this.dragging = true;
-    this.updateValueFromPosition(event.clientX);
-    this.tsInput.emit({ value: this.value });
+
+    const rawValue = this.getValueFromPosition(event.clientX, event.clientY);
+    const snapped = this.clampAndStep(rawValue);
+
+    if (this.range) {
+      const distLow = Math.abs(snapped - this.effectiveLow);
+      const distHigh = Math.abs(snapped - this.effectiveHigh);
+      this.activeThumb = distLow <= distHigh ? 'low' : 'high';
+      this.updateRangeValue(snapped);
+    } else {
+      this.value = snapped;
+    }
+    this.tsInput.emit(this.emitValues());
 
     const handleMouseMove = (e: MouseEvent): void => {
-      this.updateValueFromPosition(e.clientX);
-      this.tsInput.emit({ value: this.value });
+      const raw = this.getValueFromPosition(e.clientX, e.clientY);
+      const val = this.clampAndStep(raw);
+      if (this.range) {
+        this.updateRangeValue(val);
+      } else {
+        this.value = val;
+      }
+      this.tsInput.emit(this.emitValues());
     };
 
     const handleMouseUp = (): void => {
       this.dragging = false;
-      this.tsChange.emit({ value: this.value });
+      this.activeThumb = null;
+      this.tsChange.emit(this.emitValues());
       document.removeEventListener('mousemove', handleMouseMove);
       document.removeEventListener('mouseup', handleMouseUp);
     };
@@ -94,30 +170,44 @@ export class TsSlider {
     document.addEventListener('mouseup', handleMouseUp);
   };
 
-  private handleKeyDown = (event: KeyboardEvent): void => {
+  private updateRangeValue(val: number): void {
+    if (this.activeThumb === 'low') {
+      this.valueLow = Math.min(val, this.effectiveHigh);
+    } else {
+      this.valueHigh = Math.max(val, this.effectiveLow);
+    }
+  }
+
+  private handleKeyDown = (event: KeyboardEvent, thumb?: 'low' | 'high'): void => {
     if (this.disabled) return;
 
-    let newValue = this.value;
+    const current = this.range
+      ? (thumb === 'low' ? this.effectiveLow : this.effectiveHigh)
+      : this.value;
+    let newValue = current;
     const bigStep = this.step * 10;
 
+    const incKey = this.isVertical ? 'ArrowUp' : 'ArrowRight';
+    const decKey = this.isVertical ? 'ArrowDown' : 'ArrowLeft';
+
     switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowUp':
+      case incKey:
+      case (this.isVertical ? 'ArrowRight' : 'ArrowUp'):
         event.preventDefault();
-        newValue = this.clampAndStep(this.value + this.step);
+        newValue = this.clampAndStep(current + this.step);
         break;
-      case 'ArrowLeft':
-      case 'ArrowDown':
+      case decKey:
+      case (this.isVertical ? 'ArrowLeft' : 'ArrowDown'):
         event.preventDefault();
-        newValue = this.clampAndStep(this.value - this.step);
+        newValue = this.clampAndStep(current - this.step);
         break;
       case 'PageUp':
         event.preventDefault();
-        newValue = this.clampAndStep(this.value + bigStep);
+        newValue = this.clampAndStep(current + bigStep);
         break;
       case 'PageDown':
         event.preventDefault();
-        newValue = this.clampAndStep(this.value - bigStep);
+        newValue = this.clampAndStep(current - bigStep);
         break;
       case 'Home':
         event.preventDefault();
@@ -131,16 +221,60 @@ export class TsSlider {
         return;
     }
 
-    if (newValue !== this.value) {
-      this.value = newValue;
-      this.tsInput.emit({ value: this.value });
-      this.tsChange.emit({ value: this.value });
+    if (newValue !== current) {
+      if (this.range && thumb === 'low') {
+        this.valueLow = Math.min(newValue, this.effectiveHigh);
+      } else if (this.range && thumb === 'high') {
+        this.valueHigh = Math.max(newValue, this.effectiveLow);
+      } else {
+        this.value = newValue;
+      }
+      this.tsInput.emit(this.emitValues());
+      this.tsChange.emit(this.emitValues());
     }
   };
 
+  private renderMarks(): unknown {
+    const marks = this.parsedMarks;
+    if (marks.length === 0) return null;
+
+    const positionProp = this.isVertical ? 'bottom' : 'insetInlineStart';
+
+    return (
+      <div class="slider__marks" part="marks">
+        {marks.map((mark) => {
+          const pct = this.toPercent(mark.value);
+          return (
+            <div class="slider__mark" style={{ [positionProp]: `${pct}%` }}>
+              <div class="slider__mark-tick" />
+              {mark.label && <div class="slider__mark-label">{mark.label}</div>}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
-    const percent = this.percentage;
+    const isRange = this.range;
+    const lowPct = isRange ? this.toPercent(this.effectiveLow) : 0;
+    const highPct = isRange ? this.toPercent(this.effectiveHigh) : this.percentage;
+    const singlePct = this.percentage;
+
+    const fillStyle = this.isVertical
+      ? isRange
+        ? { bottom: `${lowPct}%`, height: `${highPct - lowPct}%` }
+        : { bottom: '0%', height: `${singlePct}%` }
+      : isRange
+        ? { insetInlineStart: `${lowPct}%`, width: `${highPct - lowPct}%` }
+        : { width: `${singlePct}%` };
+
+    const thumbPos = this.isVertical ? 'bottom' : 'insetInlineStart';
+
+    const displayValue = isRange
+      ? `${this.effectiveLow} – ${this.effectiveHigh}`
+      : `${this.value}`;
 
     return (
       <Host
@@ -148,17 +282,19 @@ export class TsSlider {
           'ts-slider': true,
           [`ts-slider--${this.size}`]: true,
           'ts-slider--disabled': this.disabled,
+          'ts-slider--vertical': this.isVertical,
+          'ts-slider--range': isRange,
         }}
       >
         {this.label && (
           <label class="slider__label" part="label">
             {this.label}
-            {this.showValue && <span class="slider__value">{this.value}</span>}
+            {this.showValue && <span class="slider__value">{displayValue}</span>}
           </label>
         )}
         {!this.label && this.showValue && (
           <span class="slider__value" part="label" aria-hidden="true">
-            {this.value}
+            {displayValue}
           </span>
         )}
         <div
@@ -167,24 +303,55 @@ export class TsSlider {
           ref={(el) => (this.trackEl = el)}
           onMouseDown={this.handleMouseDown}
         >
-          <div
-            class="slider__fill"
-            part="fill"
-            style={{ width: `${percent}%` }}
-          />
-          <div
-            class="slider__thumb"
-            part="thumb"
-            role="slider"
-            tabindex={this.disabled ? -1 : 0}
-            aria-valuenow={this.value}
-            aria-valuemin={this.min}
-            aria-valuemax={this.max}
-            aria-label={this.label || undefined}
-            aria-disabled={this.disabled ? 'true' : undefined}
-            style={{ insetInlineStart: `${percent}%` }}
-            onKeyDown={this.handleKeyDown}
-          />
+          <div class="slider__fill" part="fill" style={fillStyle} />
+
+          {isRange ? [
+            <div
+              class="slider__thumb slider__thumb--low"
+              part="thumb-low"
+              role="slider"
+              tabindex={this.disabled ? -1 : 0}
+              aria-valuenow={this.effectiveLow}
+              aria-valuemin={this.min}
+              aria-valuemax={this.effectiveHigh}
+              aria-label={this.label ? `${this.label} minimum` : 'Minimum'}
+              aria-disabled={this.disabled ? 'true' : undefined}
+              aria-orientation={this.orientation}
+              style={{ [thumbPos]: `${lowPct}%` }}
+              onKeyDown={(e: KeyboardEvent) => this.handleKeyDown(e, 'low')}
+            />,
+            <div
+              class="slider__thumb slider__thumb--high"
+              part="thumb-high"
+              role="slider"
+              tabindex={this.disabled ? -1 : 0}
+              aria-valuenow={this.effectiveHigh}
+              aria-valuemin={this.effectiveLow}
+              aria-valuemax={this.max}
+              aria-label={this.label ? `${this.label} maximum` : 'Maximum'}
+              aria-disabled={this.disabled ? 'true' : undefined}
+              aria-orientation={this.orientation}
+              style={{ [thumbPos]: `${highPct}%` }}
+              onKeyDown={(e: KeyboardEvent) => this.handleKeyDown(e, 'high')}
+            />,
+          ] : (
+            <div
+              class="slider__thumb"
+              part="thumb"
+              role="slider"
+              tabindex={this.disabled ? -1 : 0}
+              aria-valuenow={this.value}
+              aria-valuemin={this.min}
+              aria-valuemax={this.max}
+              aria-label={this.label || undefined}
+              aria-disabled={this.disabled ? 'true' : undefined}
+              aria-orientation={this.orientation}
+              style={{ [thumbPos]: `${singlePct}%` }}
+              onKeyDown={(e: KeyboardEvent) => this.handleKeyDown(e)}
+            />
+          )}
+
+          {this.renderMarks()}
         </div>
       </Host>
     );


### PR DESCRIPTION
## Summary
- **Range mode**: dual thumbs for min-max selection (e.g., price filter), with `valueLow`/`valueHigh` props and proper ARIA
- **Marks/ticks**: labeled tick marks at specified positions via JSON `marks` prop
- **Vertical orientation**: bottom-to-top slider via `orientation="vertical"` prop
- Fully backward compatible with existing single-value usage

## Test plan
- [x] 14 unit tests (existing 9 + 5 new for range, marks, vertical)
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)