### PR TITLE
feat(breadcrumb): add icon support and collapsible items

### DIFF
--- a/src/components/breadcrumb/breadcrumb-item.css
+++ b/src/components/breadcrumb/breadcrumb-item.css
@@ -37,6 +37,13 @@
   font-weight: var(--ts-font-weight-semi);
 }
 
+/* ---- Icon ---- */
+::slotted([slot="icon"]) {
+  display: inline-flex;
+  margin-inline-end: var(--ts-spacing-1);
+  vertical-align: middle;
+}
+
 .breadcrumb-item__separator {
   color: var(--ts-breadcrumb-separator-color, var(--ts-color-text-tertiary));
   margin-inline: var(--ts-spacing-1);

--- a/src/components/breadcrumb/breadcrumb-item.tsx
+++ b/src/components/breadcrumb/breadcrumb-item.tsx
@@ -2,6 +2,7 @@ import { Component, Prop, h, Host } from '@stencil/core';
 
 /**
  * @slot - Default slot for label text.
+ * @slot icon - Optional icon slot rendered before the label.
  *
  * @part link - The anchor or span element.
  * @part separator - The separator element.
@@ -30,6 +31,7 @@ export class TsBreadcrumbItem {
         <li class="breadcrumb-item__li">
           {isLink ? (
             <a href={this.href} part="link" class="breadcrumb-item__link">
+              <slot name="icon" />
               <slot />
             </a>
           ) : (
@@ -38,6 +40,7 @@ export class TsBreadcrumbItem {
               class="breadcrumb-item__text"
               aria-current={this.current ? 'page' : undefined}
             >
+              <slot name="icon" />
               <slot />
             </span>
           )}

--- a/src/components/breadcrumb/breadcrumb.spec.ts
+++ b/src/components/breadcrumb/breadcrumb.spec.ts
@@ -51,6 +51,28 @@ describe('ts-breadcrumb', () => {
 
     expect(page.rootInstance.separator).toBe('>');
   });
+
+  it('hides middle items when maxItems is set', async () => {
+    const page = await newSpecPage({
+      components: [TsBreadcrumb],
+      html: `
+        <ts-breadcrumb max-items="3">
+          <ts-breadcrumb-item>A</ts-breadcrumb-item>
+          <ts-breadcrumb-item>B</ts-breadcrumb-item>
+          <ts-breadcrumb-item>C</ts-breadcrumb-item>
+          <ts-breadcrumb-item>D</ts-breadcrumb-item>
+          <ts-breadcrumb-item>E</ts-breadcrumb-item>
+        </ts-breadcrumb>
+      `,
+    });
+
+    const items = page.root?.querySelectorAll('ts-breadcrumb-item');
+    // First item visible, last 2 visible, middle 2 hidden
+    expect(items?.[1]?.style.display).toBe('none');
+    expect(items?.[2]?.style.display).toBe('none');
+    expect(items?.[0]?.style.display).not.toBe('none');
+    expect(items?.[4]?.style.display).not.toBe('none');
+  });
 });
 
 describe('ts-breadcrumb-item', () => {

--- a/src/components/breadcrumb/breadcrumb.stories.ts
+++ b/src/components/breadcrumb/breadcrumb.stories.ts
@@ -89,3 +89,31 @@ export const Composition = (): string => `
     </div>
   </div>
 `;
+
+export const WithIcons = (): string => `
+  <ts-breadcrumb>
+    <ts-breadcrumb-item href="/">
+      <ts-icon slot="icon" name="home" size="sm"></ts-icon>
+      Home
+    </ts-breadcrumb-item>
+    <ts-breadcrumb-item href="/products">
+      <ts-icon slot="icon" name="folder" size="sm"></ts-icon>
+      Products
+    </ts-breadcrumb-item>
+    <ts-breadcrumb-item current>
+      <ts-icon slot="icon" name="file" size="sm"></ts-icon>
+      Widget Pro
+    </ts-breadcrumb-item>
+  </ts-breadcrumb>
+`;
+
+export const Collapsible = (): string => `
+  <ts-breadcrumb max-items="3">
+    <ts-breadcrumb-item href="/">Home</ts-breadcrumb-item>
+    <ts-breadcrumb-item href="/docs">Documentation</ts-breadcrumb-item>
+    <ts-breadcrumb-item href="/docs/components">Components</ts-breadcrumb-item>
+    <ts-breadcrumb-item href="/docs/components/forms">Forms</ts-breadcrumb-item>
+    <ts-breadcrumb-item href="/docs/components/forms/input">Input</ts-breadcrumb-item>
+    <ts-breadcrumb-item current>Validation</ts-breadcrumb-item>
+  </ts-breadcrumb>
+`;

--- a/src/components/breadcrumb/breadcrumb.tsx
+++ b/src/components/breadcrumb/breadcrumb.tsx
@@ -17,6 +17,9 @@ export class TsBreadcrumb {
   /** The separator character between breadcrumb items. */
   @Prop() separator = '/';
 
+  /** Maximum number of visible items. Middle items are hidden when exceeded. */
+  @Prop() maxItems?: number;
+
   componentDidRender(): void {
     const items = this.hostEl.querySelectorAll('ts-breadcrumb-item');
     items.forEach((item, index) => {
@@ -26,6 +29,24 @@ export class TsBreadcrumb {
         item.removeAttribute('separator');
       }
     });
+
+    // Collapse middle items when maxItems is set
+    if (this.maxItems !== undefined && items.length > this.maxItems) {
+      const lastVisibleCount = this.maxItems - 1;
+      const hideStart = 1;
+      const hideEnd = items.length - lastVisibleCount;
+      items.forEach((item, index) => {
+        if (index >= hideStart && index < hideEnd) {
+          (item as HTMLElement).style.display = 'none';
+        } else {
+          (item as HTMLElement).style.display = '';
+        }
+      });
+    } else {
+      items.forEach((item) => {
+        (item as HTMLElement).style.display = '';
+      });
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type


### PR DESCRIPTION
## Summary
- Add `icon` slot to `ts-breadcrumb-item` for prefix icons (e.g., home icon on first item)
- Add `maxItems` prop to `ts-breadcrumb` to collapse middle items in deep paths

## Test plan
- [x] 12 unit tests pass (existing + new for maxItems collapse)
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)