### PR TITLE
docs: document spacing scale with gap explanation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig({
             { label: 'Design Principles', slug: 'design-language/principles' },
             { label: 'Color', slug: 'design-language/color' },
             { label: 'Typography', slug: 'design-language/typography' },
+            { label: 'Spacing', slug: 'design-language/spacing' },
             { label: 'Layout', slug: 'design-language/layout' },
             { label: 'Elevation', slug: 'design-language/elevation' },
             { label: 'Shapes', slug: 'design-language/shapes' },

--- a/docs/src/content/docs/design-language/spacing.mdx
+++ b/docs/src/content/docs/design-language/spacing.mdx
@@ -1,0 +1,217 @@
+---
+title: Spacing
+description: Complete reference for the Tessera UI spacing scale, including token values across density modes and intentional numbering gaps.
+---
+
+<style>{`
+  .spacing-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-block: 1.5rem;
+    font-size: 0.875rem;
+  }
+  .spacing-table th {
+    text-align: left;
+    padding: 0.625rem 1rem;
+    border-block-end: 2px solid var(--sl-color-gray-5);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .spacing-table td {
+    padding: 0.625rem 1rem;
+    border-block-end: 1px solid var(--sl-color-gray-6);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8125rem;
+  }
+  .spacing-table tr:last-child td {
+    border-block-end: none;
+  }
+  .spacing-bar-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .spacing-bar {
+    height: 20px;
+    border-radius: 6px;
+    background: linear-gradient(135deg, #1a73e8, #4285f4);
+    min-width: 2px;
+    flex-shrink: 0;
+  }
+  .skipped-row td {
+    color: var(--sl-color-gray-4);
+    font-style: italic;
+  }
+  .gap-callout {
+    margin-block: 2rem;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(26, 115, 232, 0.25);
+    background: rgba(26, 115, 232, 0.05);
+    font-size: 0.875rem;
+    line-height: 1.6;
+  }
+  .gap-callout strong {
+    color: #1a73e8;
+  }
+  .gap-callout code {
+    font-size: 0.8125rem;
+  }
+`}</style>
+
+Tessera UI provides a spacing scale built on CSS custom properties. The scale uses a curated set of values rather than a linear sequence, which means some numbers are intentionally skipped.
+
+---
+
+## Spacing Scale Reference
+
+The table below shows every spacing token, its CSS value, and the resolved pixel size across all three density modes.
+
+<table class="spacing-table">
+  <thead>
+    <tr>
+      <th>Token</th>
+      <th>Default (Comfortable)</th>
+      <th>Compact</th>
+      <th>Spacious</th>
+      <th style="min-width: 120px;">Visual</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`--ts-spacing-0`</td>
+      <td>0</td>
+      <td>0</td>
+      <td>0</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 0; min-width: 0;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-1`</td>
+      <td>0.375rem (6px)</td>
+      <td>0.25rem (4px)</td>
+      <td>0.5rem (8px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 6px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-2`</td>
+      <td>0.625rem (10px)</td>
+      <td>0.5rem (8px)</td>
+      <td>0.75rem (12px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 10px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-3`</td>
+      <td>1rem (16px)</td>
+      <td>0.75rem (12px)</td>
+      <td>1.25rem (20px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 16px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-4`</td>
+      <td>1.25rem (20px)</td>
+      <td>1rem (16px)</td>
+      <td>1.5rem (24px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 20px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-5`</td>
+      <td>1.5rem (24px)</td>
+      <td>1.25rem (20px)</td>
+      <td>2rem (32px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 24px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-6`</td>
+      <td>2rem (32px)</td>
+      <td>1.5rem (24px)</td>
+      <td>2.5rem (40px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 32px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-8`</td>
+      <td>2.5rem (40px)</td>
+      <td>2.5rem (40px)</td>
+      <td>2.5rem (40px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 40px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-10`</td>
+      <td>3rem (48px)</td>
+      <td>3rem (48px)</td>
+      <td>3rem (48px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 48px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-12`</td>
+      <td>4rem (64px)</td>
+      <td>4rem (64px)</td>
+      <td>4rem (64px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 64px;"></div></div></td>
+    </tr>
+    <tr>
+      <td>`--ts-spacing-16`</td>
+      <td>5rem (80px)</td>
+      <td>5rem (80px)</td>
+      <td>5rem (80px)</td>
+      <td><div class="spacing-bar-cell"><div class="spacing-bar" style="width: 80px;"></div></div></td>
+    </tr>
+  </tbody>
+</table>
+
+:::note
+Tokens 8, 10, 12, and 16 are **not remapped** by density modes. They serve as fixed layout anchors for page-level spacing that should remain constant regardless of density setting.
+:::
+
+---
+
+## About the Numbering Gaps
+
+<div class="gap-callout">
+  <strong>Tokens 7, 9, 11, and 13-15 are intentionally skipped</strong> -- the scale maps to the geometric progression used across the component library. Rather than providing a value at every integer, the scale includes only the steps that are actually needed for consistent visual rhythm. This avoids "in-between" sizes that would create ambiguity and inconsistent spacing decisions.
+</div>
+
+The numbering after `--ts-spacing-6` switches to even increments (8, 10, 12, 16) because at larger sizes the visual difference between adjacent steps is less perceptible and fewer stops are needed. The numbers themselves reflect relative magnitude rather than a sequential index.
+
+**Do not create custom tokens to fill the gaps.** If you find yourself needing a value between two existing tokens, consider whether one of the existing tokens is a better fit for the use case.
+
+---
+
+## When to Use Each Token
+
+| Token | Default Value | Typical Usage |
+|---|---|---|
+| `--ts-spacing-0` | 0 | Reset spacing, flush alignment |
+| `--ts-spacing-1` | 6px | Tightest gap -- icon to label, label to field |
+| `--ts-spacing-2` | 10px | Inline padding, small gaps between related items |
+| `--ts-spacing-3` | 16px | Standard component internal padding |
+| `--ts-spacing-4` | 20px | Section gaps, medium component padding |
+| `--ts-spacing-5` | 24px | Card padding, form group separation |
+| `--ts-spacing-6` | 32px | Large container padding, section dividers |
+| `--ts-spacing-8` | 40px | Page section separation |
+| `--ts-spacing-10` | 48px | Major layout regions |
+| `--ts-spacing-12` | 64px | Page-level vertical rhythm |
+| `--ts-spacing-16` | 80px | Hero sections, maximum breathing room |
+
+---
+
+## Usage in CSS
+
+Always reference spacing tokens rather than hard-coded values:
+
+```css
+/* Correct */
+.card {
+  padding: var(--ts-spacing-3);
+  gap: var(--ts-spacing-2);
+}
+
+/* Incorrect -- bypasses density modes */
+.card {
+  padding: 16px;
+  gap: 10px;
+}
+```
+
+Using tokens ensures your layout automatically adjusts when a user or container switches density via the `data-density` attribute. See the [Layout](/design-language/layout/) page for density modes, grid system, and breakpoint details.


### PR DESCRIPTION
## Summary
- Add comprehensive spacing scale reference page at `docs/design-language/spacing`
- Document all tokens with values across default, compact, and spacious density modes
- Explain why tokens 7, 9, 11, and 13-15 are intentionally skipped
- Include usage guidance table and CSS code examples

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)