### PR TITLE
feat(pagination): add first/last buttons and info text

### DIFF
--- a/src/components/pagination/pagination.css
+++ b/src/components/pagination/pagination.css
@@ -8,7 +8,9 @@
    ========================================================================== */
 
 :host {
-  display: block;
+  display: flex;
+  align-items: center;
+  gap: var(--ts-spacing-3);
 
   --ts-pagination-button-size: 2.25rem;
   --ts-pagination-active-bg: var(--ts-color-interactive-primary);
@@ -19,6 +21,14 @@
   display: flex;
   align-items: center;
   gap: var(--ts-spacing-1);
+}
+
+/* ---- Info text ---- */
+.pagination__info {
+  font-family: var(--ts-font-family-base);
+  font-size: var(--ts-font-size-sm);
+  color: var(--ts-color-text-secondary);
+  white-space: nowrap;
 }
 
 /* ---- Buttons ---- */
@@ -65,9 +75,11 @@
   font-weight: var(--ts-font-weight-semi);
 }
 
-/* ---- Prev/Next arrows ---- */
+/* ---- Prev/Next/First/Last arrows ---- */
 .pagination__prev svg,
-.pagination__next svg {
+.pagination__next svg,
+.pagination__first svg,
+.pagination__last svg {
   inline-size: 1em;
   block-size: 1em;
 }

--- a/src/components/pagination/pagination.spec.ts
+++ b/src/components/pagination/pagination.spec.ts
@@ -90,4 +90,47 @@ describe('ts-pagination', () => {
 
     expect(page.root?.getAttribute('size')).toBe('sm');
   });
+
+  it('renders first/last buttons when showFirstLast is true', async () => {
+    const page = await newSpecPage({
+      components: [TsPagination],
+      html: '<ts-pagination total="100" page-size="10" current-page="5" show-first-last="true"></ts-pagination>',
+    });
+
+    const firstBtn = page.root?.shadowRoot?.querySelector('.pagination__first');
+    const lastBtn = page.root?.shadowRoot?.querySelector('.pagination__last');
+    expect(firstBtn).not.toBeNull();
+    expect(lastBtn).not.toBeNull();
+  });
+
+  it('disables first button on page 1', async () => {
+    const page = await newSpecPage({
+      components: [TsPagination],
+      html: '<ts-pagination total="100" page-size="10" current-page="1" show-first-last="true"></ts-pagination>',
+    });
+
+    const firstBtn = page.root?.shadowRoot?.querySelector('.pagination__first');
+    expect(firstBtn?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('disables last button on last page', async () => {
+    const page = await newSpecPage({
+      components: [TsPagination],
+      html: '<ts-pagination total="50" page-size="10" current-page="5" show-first-last="true"></ts-pagination>',
+    });
+
+    const lastBtn = page.root?.shadowRoot?.querySelector('.pagination__last');
+    expect(lastBtn?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('renders info text when showInfo is true', async () => {
+    const page = await newSpecPage({
+      components: [TsPagination],
+      html: '<ts-pagination total="100" page-size="10" current-page="3" show-info="true"></ts-pagination>',
+    });
+
+    const info = page.root?.shadowRoot?.querySelector('.pagination__info');
+    expect(info).not.toBeNull();
+    expect(info?.textContent).toBe('Showing 21-30 of 100');
+  });
 });

--- a/src/components/pagination/pagination.stories.ts
+++ b/src/components/pagination/pagination.stories.ts
@@ -25,6 +25,14 @@ export default {
       options: ['sm', 'md', 'lg'],
       description: 'The size of the pagination buttons.',
     },
+    showFirstLast: {
+      control: 'boolean',
+      description: 'Show first/last page buttons.',
+    },
+    showInfo: {
+      control: 'boolean',
+      description: 'Show "Showing X-Y of Z" info text.',
+    },
   },
 };
 
@@ -35,6 +43,8 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.currentPage !== undefined) attrs.push(`current-page="${args.currentPage}"`);
   if (args.siblingCount !== undefined) attrs.push(`sibling-count="${args.siblingCount}"`);
   if (args.size !== undefined) attrs.push(`size="${args.size}"`);
+  if (args.showFirstLast) attrs.push(`show-first-last="true"`);
+  if (args.showInfo) attrs.push(`show-info="true"`);
   return `<ts-pagination ${attrs.join(' ')}></ts-pagination>`;
 };
 
@@ -88,5 +98,48 @@ export const Composition = (): string => `
       <span style="font-size: 14px; color: #666;">Showing 41-50 of 237 results</span>
     </div>
     <ts-pagination total="237" page-size="10" current-page="5" sibling-count="2"></ts-pagination>
+  </div>
+`;
+
+export const WithFirstLast = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">First page (first button disabled)</p>
+      <ts-pagination total="200" page-size="10" current-page="1" show-first-last="true"></ts-pagination>
+    </div>
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Middle page</p>
+      <ts-pagination total="200" page-size="10" current-page="10" show-first-last="true"></ts-pagination>
+    </div>
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Last page (last button disabled)</p>
+      <ts-pagination total="200" page-size="10" current-page="20" show-first-last="true"></ts-pagination>
+    </div>
+  </div>
+`;
+
+export const WithInfo = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Page 1 of 10</p>
+      <ts-pagination total="100" page-size="10" current-page="1" show-info="true"></ts-pagination>
+    </div>
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Page 5 of 10</p>
+      <ts-pagination total="100" page-size="10" current-page="5" show-info="true"></ts-pagination>
+    </div>
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Last page with partial results</p>
+      <ts-pagination total="93" page-size="10" current-page="10" show-info="true"></ts-pagination>
+    </div>
+  </div>
+`;
+
+export const FullFeatured = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px;">
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">All features enabled</p>
+      <ts-pagination total="237" page-size="10" current-page="5" sibling-count="2" show-first-last="true" show-info="true"></ts-pagination>
+    </div>
   </div>
 `;

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -7,6 +7,9 @@ import type { TsSize } from '../../types';
  * @part button - Each page button.
  * @part prev - The previous button.
  * @part next - The next button.
+ * @part first - The first page button.
+ * @part last - The last page button.
+ * @part info - The info text element.
  */
 @Component({
   tag: 'ts-pagination',
@@ -28,6 +31,12 @@ export class TsPagination {
 
   /** The size of the pagination buttons. */
   @Prop({ reflect: true }) size: TsSize = 'md';
+
+  /** Show first/last page buttons. */
+  @Prop() showFirstLast = false;
+
+  /** Show "Showing X-Y of Z" info text. */
+  @Prop() showInfo = false;
 
   /** Emitted when the page changes. */
   @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ page: number }>;
@@ -92,6 +101,9 @@ export class TsPagination {
     const isFirstPage = this.currentPage <= 1;
     const isLastPage = this.currentPage >= this.totalPages;
 
+    const rangeStart = (this.currentPage - 1) * this.pageSize + 1;
+    const rangeEnd = Math.min(this.currentPage * this.pageSize, this.total);
+
     return (
       <Host
         class={{
@@ -99,7 +111,27 @@ export class TsPagination {
           [`ts-pagination--${this.size}`]: true,
         }}
       >
+        {this.showInfo && (
+          <span part="info" class="pagination__info">
+            Showing {rangeStart}-{rangeEnd} of {this.total}
+          </span>
+        )}
         <nav part="nav" aria-label="Pagination" class="pagination__nav">
+          {this.showFirstLast && (
+            <button
+              class="pagination__button pagination__first"
+              part="first"
+              disabled={isFirstPage}
+              aria-label="First page"
+              onClick={() => this.handlePageClick(1)}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="11 18 5 12 11 6" />
+                <polyline points="19 18 13 12 19 6" />
+              </svg>
+            </button>
+          )}
+
           <button
             class="pagination__button pagination__prev"
             part="prev"
@@ -145,6 +177,21 @@ export class TsPagination {
               <polyline points="9 18 15 12 9 6" />
             </svg>
           </button>
+
+          {this.showFirstLast && (
+            <button
+              class="pagination__button pagination__last"
+              part="last"
+              disabled={isLastPage}
+              aria-label="Last page"
+              onClick={() => this.handlePageClick(this.totalPages)}
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="13 18 19 12 13 6" />
+                <polyline points="5 18 11 12 5 6" />
+              </svg>
+            </button>
+          )}
         </nav>
       </Host>
     );


### PR DESCRIPTION
## Summary
- Add `showFirstLast` prop with first/last page buttons (double chevrons)
- Add `showInfo` prop showing "Showing X-Y of Z" range text

## Test plan
- [x] 12 unit tests pass (4 new)
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)