### PR TITLE
feat(tabs): add vertical orientation, closable tabs, and scrollable overflow

### DIFF
--- a/src/components/tabs/tabs.css
+++ b/src/components/tabs/tabs.css
@@ -8,7 +8,8 @@
    ========================================================================== */
 
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
   font-family: var(--ts-font-family-base);
 
   --ts-tabs-border-color: var(--ts-color-border-default);
@@ -131,4 +132,71 @@
 /* ---- Tab icon ---- */
 .tabs__tab-icon {
   font-size: 1em;
+}
+
+/* ---- Vertical ---- */
+:host([orientation="vertical"]) {
+  flex-direction: row;
+}
+
+:host([orientation="vertical"]) .tabs__tablist {
+  flex-direction: column;
+  border-block-end: none;
+  border-inline-end: 2px solid var(--ts-tabs-border-color);
+  min-inline-size: 160px;
+}
+
+:host([orientation="vertical"]) .tabs__tab {
+  margin-block-end: 0;
+  border-block-end: none;
+  border-inline-end: 2px solid transparent;
+  margin-inline-end: -2px;
+}
+
+:host([orientation="vertical"]) .tabs__tab--active {
+  border-block-end-color: transparent;
+  border-inline-end: 2px solid var(--ts-tabs-active-color);
+}
+
+:host([orientation="vertical"]) .tabs__panels {
+  flex: 1;
+  padding-block-start: 0;
+  padding-inline-start: var(--ts-spacing-4);
+}
+
+/* ---- Close button ---- */
+.tabs__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 2px;
+  margin-inline-start: var(--ts-spacing-1);
+  color: var(--ts-color-text-tertiary);
+  border-radius: var(--ts-radius-sm);
+  font-size: 0.75em;
+  line-height: 1;
+}
+
+.tabs__close:hover {
+  color: var(--ts-color-text-primary);
+  background-color: var(--ts-color-neutral-100);
+}
+
+/* ---- Scrollable ---- */
+:host([scrollable]) .tabs__tablist {
+  overflow-x: auto;
+  scrollbar-width: none;
+  flex-wrap: nowrap;
+}
+
+:host([scrollable]) .tabs__tablist::-webkit-scrollbar {
+  display: none;
+}
+
+:host([orientation="vertical"][scrollable]) .tabs__tablist {
+  overflow-x: hidden;
+  overflow-y: auto;
 }

--- a/src/components/tabs/tabs.spec.ts
+++ b/src/components/tabs/tabs.spec.ts
@@ -152,4 +152,83 @@ describe('ts-tabs', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('applies vertical class when orientation is vertical', async () => {
+    const page = await newSpecPage({
+      components: [TsTabs, TsTabPanel],
+      html: `
+        <ts-tabs orientation="vertical" value="one">
+          <ts-tab-panel tab="Tab 1" value="one">Content 1</ts-tab-panel>
+          <ts-tab-panel tab="Tab 2" value="two">Content 2</ts-tab-panel>
+        </ts-tabs>
+      `,
+    });
+
+    expect(page.root).toHaveClass('ts-tabs--vertical');
+    expect(page.root?.getAttribute('orientation')).toBe('vertical');
+  });
+
+  it('renders close buttons when closable is true', async () => {
+    const page = await newSpecPage({
+      components: [TsTabs, TsTabPanel],
+      html: `
+        <ts-tabs closable value="one">
+          <ts-tab-panel tab="Tab 1" value="one">Content 1</ts-tab-panel>
+          <ts-tab-panel tab="Tab 2" value="two">Content 2</ts-tab-panel>
+        </ts-tabs>
+      `,
+    });
+
+    const closeButtons = page.root?.shadowRoot?.querySelectorAll('.tabs__close');
+    expect(closeButtons?.length).toBe(2);
+  });
+
+  it('does not render close button on disabled tabs', async () => {
+    const page = await newSpecPage({
+      components: [TsTabs, TsTabPanel],
+      html: `
+        <ts-tabs closable value="one">
+          <ts-tab-panel tab="Tab 1" value="one">Content 1</ts-tab-panel>
+          <ts-tab-panel tab="Tab 2" value="two" disabled>Content 2</ts-tab-panel>
+        </ts-tabs>
+      `,
+    });
+
+    const closeButtons = page.root?.shadowRoot?.querySelectorAll('.tabs__close');
+    expect(closeButtons?.length).toBe(1);
+  });
+
+  it('emits tsClose when close button is clicked', async () => {
+    const page = await newSpecPage({
+      components: [TsTabs, TsTabPanel],
+      html: `
+        <ts-tabs closable value="one">
+          <ts-tab-panel tab="Tab 1" value="one">Content 1</ts-tab-panel>
+          <ts-tab-panel tab="Tab 2" value="two">Content 2</ts-tab-panel>
+        </ts-tabs>
+      `,
+    });
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsClose', spy);
+
+    const closeButtons = page.root?.shadowRoot?.querySelectorAll<HTMLButtonElement>('.tabs__close');
+    closeButtons?.[0]?.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies scrollable class when scrollable is true', async () => {
+    const page = await newSpecPage({
+      components: [TsTabs, TsTabPanel],
+      html: `
+        <ts-tabs scrollable value="one">
+          <ts-tab-panel tab="Tab 1" value="one">Content 1</ts-tab-panel>
+          <ts-tab-panel tab="Tab 2" value="two">Content 2</ts-tab-panel>
+        </ts-tabs>
+      `,
+    });
+
+    expect(page.root).toHaveClass('ts-tabs--scrollable');
+  });
 });

--- a/src/components/tabs/tabs.stories.ts
+++ b/src/components/tabs/tabs.stories.ts
@@ -15,6 +15,19 @@ export default {
       options: ['sm', 'md', 'lg'],
       description: 'The size of the tab buttons.',
     },
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'The orientation of the tab bar.',
+    },
+    closable: {
+      control: 'boolean',
+      description: 'Whether tabs display a close button.',
+    },
+    scrollable: {
+      control: 'boolean',
+      description: 'Whether the tab list is scrollable on overflow.',
+    },
   },
 };
 
@@ -23,6 +36,9 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.value !== undefined && args.value !== null && args.value !== '') attrs.push(`value="${args.value}"`);
   if (args.variant !== undefined && args.variant !== null) attrs.push(`variant="${args.variant}"`);
   if (args.size !== undefined && args.size !== null) attrs.push(`size="${args.size}"`);
+  if (args.orientation !== undefined && args.orientation !== null) attrs.push(`orientation="${args.orientation}"`);
+  if (args.closable) attrs.push('closable');
+  if (args.scrollable) attrs.push('scrollable');
   return `
     <ts-tabs ${attrs.join(' ')}>
       <ts-tab-panel tab="Profile" value="profile">
@@ -151,6 +167,68 @@ export const WithDisabledTab = (): string => `
       </div>
     </ts-tab-panel>
   </ts-tabs>
+`;
+
+export const Vertical = (): string => `
+  <ts-tabs orientation="vertical" value="general">
+    <ts-tab-panel tab="General" value="general">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <h4 style="margin: 0 0 8px;">General Settings</h4>
+        <p style="margin: 0; color: #555;">Configure your application name, language, and timezone preferences.</p>
+      </div>
+    </ts-tab-panel>
+    <ts-tab-panel tab="Notifications" value="notifications">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <h4 style="margin: 0 0 8px;">Notification Preferences</h4>
+        <p style="margin: 0; color: #555;">Choose which notifications you receive and how they are delivered.</p>
+      </div>
+    </ts-tab-panel>
+    <ts-tab-panel tab="Security" value="security">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <h4 style="margin: 0 0 8px;">Security Settings</h4>
+        <p style="margin: 0; color: #555;">Manage two-factor authentication, active sessions, and API keys.</p>
+      </div>
+    </ts-tab-panel>
+  </ts-tabs>
+`;
+
+export const Closable = (): string => `
+  <ts-tabs closable value="dashboard">
+    <ts-tab-panel tab="Dashboard" value="dashboard">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <p style="margin: 0;">Main dashboard overview with key metrics and activity feed.</p>
+      </div>
+    </ts-tab-panel>
+    <ts-tab-panel tab="Reports" value="reports">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <p style="margin: 0;">Generate and view detailed analytics reports.</p>
+      </div>
+    </ts-tab-panel>
+    <ts-tab-panel tab="Logs" value="logs">
+      <div style="padding: 16px; font-family: sans-serif;">
+        <p style="margin: 0;">System event logs and audit trail.</p>
+      </div>
+    </ts-tab-panel>
+  </ts-tabs>
+`;
+
+export const Scrollable = (): string => `
+  <div style="max-width: 400px;">
+    <ts-tabs scrollable value="jan">
+      <ts-tab-panel tab="January" value="jan"><div style="padding: 16px; font-family: sans-serif;">January data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="February" value="feb"><div style="padding: 16px;">February data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="March" value="mar"><div style="padding: 16px;">March data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="April" value="apr"><div style="padding: 16px;">April data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="May" value="may"><div style="padding: 16px;">May data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="June" value="jun"><div style="padding: 16px;">June data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="July" value="jul"><div style="padding: 16px;">July data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="August" value="aug"><div style="padding: 16px;">August data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="September" value="sep"><div style="padding: 16px;">September data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="October" value="oct"><div style="padding: 16px;">October data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="November" value="nov"><div style="padding: 16px;">November data and metrics.</div></ts-tab-panel>
+      <ts-tab-panel tab="December" value="dec"><div style="padding: 16px;">December data and metrics.</div></ts-tab-panel>
+    </ts-tabs>
+  </div>
 `;
 
 export const DashboardExample = (): string => `

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -8,6 +8,7 @@ import type { EventEmitter } from '@stencil/core';
  * @part tab - Each individual tab button.
  * @part tab-active - The currently active tab button.
  * @part panels - The panel container.
+ * @part close - The close button inside closable tabs.
  */
 @Component({
   tag: 'ts-tabs',
@@ -26,8 +27,20 @@ export class TsTabs {
   /** The size of the tab buttons. */
   @Prop({ reflect: true }) size: 'sm' | 'md' | 'lg' = 'md';
 
+  /** The orientation of the tab bar. */
+  @Prop({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+
+  /** Whether tabs display a close button. */
+  @Prop({ reflect: true }) closable = false;
+
+  /** Whether the tab list is scrollable on overflow. */
+  @Prop({ reflect: true }) scrollable = false;
+
   /** Emitted when the active tab changes. */
   @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string }>;
+
+  /** Emitted when a tab's close button is clicked. */
+  @Event({ eventName: 'tsClose' }) tsClose!: EventEmitter<{ value: string }>;
 
   @Watch('value')
   handleValueChange(): void {
@@ -73,6 +86,11 @@ export class TsTabs {
     this.updatePanelVisibility();
   }
 
+  private handleCloseClick(event: MouseEvent, tabValue: string): void {
+    event.stopPropagation();
+    this.tsClose.emit({ value: tabValue });
+  }
+
   private handleKeydown = (event: KeyboardEvent): void => {
     const tabs = this.getTabData();
     const enabledTabs = tabs.filter((t) => !t.disabled);
@@ -80,14 +98,15 @@ export class TsTabs {
 
     let newIndex = currentIndex;
 
+    const nextKeys = this.orientation === 'vertical' ? ['ArrowDown'] : ['ArrowRight'];
+    const prevKeys = this.orientation === 'vertical' ? ['ArrowUp'] : ['ArrowLeft'];
+
     switch (event.key) {
-      case 'ArrowRight':
-      case 'ArrowDown':
+      case nextKeys[0]:
         event.preventDefault();
         newIndex = (currentIndex + 1) % enabledTabs.length;
         break;
-      case 'ArrowLeft':
-      case 'ArrowUp':
+      case prevKeys[0]:
         event.preventDefault();
         newIndex = (currentIndex - 1 + enabledTabs.length) % enabledTabs.length;
         break;
@@ -126,6 +145,8 @@ export class TsTabs {
           'ts-tabs': true,
           [`ts-tabs--${this.variant}`]: true,
           [`ts-tabs--${this.size}`]: true,
+          'ts-tabs--vertical': this.orientation === 'vertical',
+          'ts-tabs--scrollable': this.scrollable,
         }}
       >
         <div class="tabs__tablist" part="tablist" role="tablist" onKeyDown={this.handleKeydown}>
@@ -151,6 +172,17 @@ export class TsTabs {
               >
                 {t.icon && <ts-icon name={t.icon} class="tabs__tab-icon" />}
                 {t.tab}
+                {this.closable && !t.disabled && (
+                  <button
+                    class="tabs__close"
+                    part="close"
+                    type="button"
+                    aria-label={`Close ${t.tab}`}
+                    onClick={(e: MouseEvent) => this.handleCloseClick(e, t.value)}
+                  >
+                    &times;
+                  </button>
+                )}
               </button>
             );
           })}


### PR DESCRIPTION
## Summary
- Add `orientation` prop (vertical/horizontal) for vertical tab layouts
- Add `closable` prop with per-tab close button and `tsClose` event
- Add `scrollable` prop for overflow handling with hidden scrollbar

## Test plan
- [x] 14 unit tests pass
- [x] Build passes
- [x] Lint passes

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)