### PR TITLE
feat(toast): add pause-on-hover and progress bar

### DIFF
--- a/src/components/toast/toast.css
+++ b/src/components/toast/toast.css
@@ -67,6 +67,7 @@
 
 /* ---- Base ---- */
 .toast__base {
+  position: relative;
   display: flex;
   align-items: flex-start;
   gap: var(--ts-spacing-3);
@@ -79,6 +80,7 @@
   font-size: var(--ts-font-size-sm);
   line-height: var(--ts-line-height-normal);
   animation: ts-toast-slide-in 0.3s ease-out;
+  overflow: hidden;
 }
 
 @keyframes ts-toast-slide-in {
@@ -178,6 +180,27 @@
   opacity: 1;
 }
 
+/* ---- Progress bar ---- */
+.toast__progress {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  block-size: 3px;
+  background-color: currentColor;
+  opacity: 0.3;
+  border-radius: 0 0 var(--ts-radius-md) var(--ts-radius-md);
+  animation: ts-toast-progress linear forwards;
+}
+
+.toast__progress--paused {
+  animation-play-state: paused;
+}
+
+@keyframes ts-toast-progress {
+  from { inline-size: 100%; }
+  to { inline-size: 0%; }
+}
+
 /* ---- Reduced motion ---- */
 @media (prefers-reduced-motion: reduce) {
   .toast__base {
@@ -186,5 +209,9 @@
 
   .toast__close {
     transition-duration: 0.01ms !important;
+  }
+
+  .toast__progress {
+    animation-duration: 0.01ms !important;
   }
 }

--- a/src/components/toast/toast.spec.ts
+++ b/src/components/toast/toast.spec.ts
@@ -119,6 +119,81 @@ describe('ts-toast', () => {
     expect(page.root?.getAttribute('position')).toBe('bottom-left');
   });
 
+  it('renders progress bar when showProgress is true and open', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open show-progress duration="5000">Message</ts-toast>',
+    });
+
+    const progress = page.root?.shadowRoot?.querySelector('.toast__progress');
+    expect(progress).not.toBeNull();
+  });
+
+  it('does not render progress bar when showProgress is false', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open duration="5000">Message</ts-toast>',
+    });
+
+    const progress = page.root?.shadowRoot?.querySelector('.toast__progress');
+    expect(progress).toBeNull();
+  });
+
+  it('does not render progress bar when duration is 0', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open show-progress duration="0">Message</ts-toast>',
+    });
+
+    const progress = page.root?.shadowRoot?.querySelector('.toast__progress');
+    expect(progress).toBeNull();
+  });
+
+  it('sets isPaused state on mouseenter and clears on mouseleave', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open pause-on-hover duration="5000">Message</ts-toast>',
+    });
+
+    const toast = page.rootInstance as TsToast;
+    expect(toast.isPaused).toBe(false);
+
+    const base = page.root?.shadowRoot?.querySelector('.toast__base') as HTMLElement;
+    base?.dispatchEvent(new Event('mouseenter'));
+    await page.waitForChanges();
+
+    expect(toast.isPaused).toBe(true);
+
+    base?.dispatchEvent(new Event('mouseleave'));
+    await page.waitForChanges();
+
+    expect(toast.isPaused).toBe(false);
+  });
+
+  it('adds paused class to progress bar when hovered', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open show-progress pause-on-hover duration="5000">Message</ts-toast>',
+    });
+
+    const base = page.root?.shadowRoot?.querySelector('.toast__base') as HTMLElement;
+    base?.dispatchEvent(new Event('mouseenter'));
+    await page.waitForChanges();
+
+    const progress = page.root?.shadowRoot?.querySelector('.toast__progress');
+    expect(progress?.classList.contains('toast__progress--paused')).toBe(true);
+  });
+
+  it('has pauseOnHover defaulting to true', async () => {
+    const page = await newSpecPage({
+      components: [TsToast],
+      html: '<ts-toast open>Message</ts-toast>',
+    });
+
+    const toast = page.rootInstance as TsToast;
+    expect(toast.pauseOnHover).toBe(true);
+  });
+
   it('populates content into existing live region when opened', async () => {
     const page = await newSpecPage({
       components: [TsToast],

--- a/src/components/toast/toast.stories.ts
+++ b/src/components/toast/toast.stories.ts
@@ -26,6 +26,14 @@ export default {
       options: ['top-right', 'top-left', 'bottom-right', 'bottom-left', 'top-center', 'bottom-center'],
       description: 'Position of the toast on screen.',
     },
+    pauseOnHover: {
+      control: 'boolean',
+      description: 'Whether auto-dismiss pauses on hover/focus.',
+    },
+    showProgress: {
+      control: 'boolean',
+      description: 'Whether to show a countdown progress bar.',
+    },
     slotContent: {
       control: 'text',
       description: 'Default slot content',
@@ -40,6 +48,8 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.dismissible !== undefined && args.dismissible) attrs.push('dismissible');
   if (args.open) attrs.push('open');
   if (args.position !== undefined) attrs.push(`position="${args.position}"`);
+  if (args.pauseOnHover !== undefined && args.pauseOnHover) attrs.push('pause-on-hover');
+  if (args.showProgress !== undefined && args.showProgress) attrs.push('show-progress');
   return `<ts-toast ${attrs.join(' ')}>${args.slotContent || ''}</ts-toast>`;
 };
 
@@ -74,6 +84,27 @@ export const States = (): string => `
       <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Not dismissible</p>
       <ts-toast variant="warning" open duration="0" style="position: relative;">This toast cannot be manually dismissed</ts-toast>
     </div>
+  </div>
+`;
+
+export const PauseOnHover = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 12px; position: relative;">
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Hover over the toast to pause auto-dismiss (default behavior)</p>
+      <ts-toast variant="info" open duration="8000" pause-on-hover dismissible style="position: relative;">Hover me to pause the countdown — I auto-dismiss in 8 seconds</ts-toast>
+    </div>
+    <div>
+      <p style="margin: 0 0 8px; font-family: sans-serif; font-size: 14px; color: #666;">Pause disabled — auto-dismiss continues on hover</p>
+      <ts-toast variant="warning" open duration="8000" pause-on-hover="false" dismissible style="position: relative;">I will auto-dismiss even if you hover me</ts-toast>
+    </div>
+  </div>
+`;
+
+export const WithProgressBar = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 12px; position: relative;">
+    <ts-toast variant="success" open duration="8000" show-progress dismissible style="position: relative;">File uploaded successfully — auto-dismiss with progress bar</ts-toast>
+    <ts-toast variant="info" open duration="10000" show-progress pause-on-hover dismissible style="position: relative;">Hover to pause the progress bar countdown</ts-toast>
+    <ts-toast variant="danger" open duration="6000" show-progress dismissible style="position: relative;">Error detected — dismissing in 6 seconds</ts-toast>
   </div>
 `;
 

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -13,6 +13,7 @@ type TsToastPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
  * @part message - The message wrapper.
  * @part action - The action slot wrapper.
  * @part close - The close button.
+ * @part progress - The countdown progress bar.
  */
 @Component({
   tag: 'ts-toast',
@@ -21,6 +22,7 @@ type TsToastPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
 })
 export class TsToast {
   private autoCloseTimer?: ReturnType<typeof setTimeout>;
+  private startTime = 0;
 
   /** The toast's visual variant. */
   @Prop({ reflect: true }) variant: TsToastVariant = 'info';
@@ -37,18 +39,29 @@ export class TsToast {
   /** Position of the toast on screen. */
   @Prop({ reflect: true }) position: TsToastPosition = 'top-right';
 
+  /** Whether auto-dismiss pauses when the toast is hovered or focused. */
+  @Prop() pauseOnHover = true;
+
+  /** Whether to show a countdown progress bar at the bottom. */
+  @Prop() showProgress = false;
+
   /** Emitted when the toast is dismissed. */
   @Event({ eventName: 'tsClose' }) tsClose!: EventEmitter<void>;
 
   @State() isVisible = false;
+  @State() remainingTime = 0;
+  @State() isPaused = false;
 
   @Watch('open')
   handleOpenChange(newValue: boolean): void {
     if (newValue) {
       this.isVisible = true;
+      this.remainingTime = this.duration;
+      this.isPaused = false;
       this.startAutoClose();
     } else {
       this.isVisible = false;
+      this.isPaused = false;
       this.clearAutoClose();
     }
   }
@@ -56,6 +69,7 @@ export class TsToast {
   connectedCallback(): void {
     if (this.open) {
       this.isVisible = true;
+      this.remainingTime = this.duration;
       this.startAutoClose();
     }
   }
@@ -81,10 +95,11 @@ export class TsToast {
 
   private startAutoClose(): void {
     this.clearAutoClose();
-    if (this.duration > 0) {
+    if (this.remainingTime > 0) {
+      this.startTime = Date.now();
       this.autoCloseTimer = setTimeout(() => {
         this.close();
-      }, this.duration);
+      }, this.remainingTime);
     }
   }
 
@@ -94,6 +109,30 @@ export class TsToast {
       this.autoCloseTimer = undefined;
     }
   }
+
+  private handleMouseEnter = (): void => {
+    if (this.pauseOnHover && this.duration > 0) {
+      this.isPaused = true;
+      this.clearAutoClose();
+      const elapsed = Date.now() - this.startTime;
+      this.remainingTime = Math.max(0, this.remainingTime - elapsed);
+    }
+  };
+
+  private handleMouseLeave = (): void => {
+    if (this.pauseOnHover && this.duration > 0) {
+      this.isPaused = false;
+      this.startAutoClose();
+    }
+  };
+
+  private handleFocus = (): void => {
+    this.handleMouseEnter();
+  };
+
+  private handleBlur = (): void => {
+    this.handleMouseLeave();
+  };
 
   private handleClose = (): void => {
     this.close();
@@ -127,7 +166,14 @@ export class TsToast {
         aria-live={ariaLive}
       >
         {this.isVisible && (
-          <div class="toast__base" part="base">
+          <div
+            class="toast__base"
+            part="base"
+            onMouseEnter={this.handleMouseEnter}
+            onMouseLeave={this.handleMouseLeave}
+            onFocus={this.handleFocus}
+            onBlur={this.handleBlur}
+          >
             <div class="toast__icon" part="icon">
               {this.renderIcon()}
             </div>
@@ -150,6 +196,17 @@ export class TsToast {
               >
                 \u2715
               </button>
+            )}
+
+            {this.showProgress && this.duration > 0 && (
+              <div
+                class={{
+                  'toast__progress': true,
+                  'toast__progress--paused': this.isPaused,
+                }}
+                part="progress"
+                style={{ animationDuration: `${this.duration}ms` }}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary
- Add `pauseOnHover` prop (default true) that pauses auto-dismiss on hover/focus
- Add `showProgress` prop that renders an animated countdown bar at the bottom

## Test plan
- [x] 18 unit tests pass
- [x] Build passes
- [x] Lint passes

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)