### PR TITLE
feat(file-upload): add file list display and max file count

### DIFF
--- a/src/components/file-upload/file-upload.css
+++ b/src/components/file-upload/file-upload.css
@@ -82,3 +82,60 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* ---- File list ---- */
+.file-upload__list {
+  margin-block-start: var(--ts-spacing-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ts-spacing-1);
+}
+
+.file-upload__file {
+  display: flex;
+  align-items: center;
+  gap: var(--ts-spacing-2);
+  padding: var(--ts-spacing-1) var(--ts-spacing-2);
+  font-family: var(--ts-font-family-base);
+  font-size: var(--ts-font-size-sm);
+  color: var(--ts-color-text-primary);
+  background-color: var(--ts-color-bg-surface);
+  border: 1px solid var(--ts-color-border-default);
+  border-radius: var(--ts-radius-md);
+}
+
+.file-upload__file-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-upload__file-size {
+  color: var(--ts-color-text-tertiary);
+  font-size: var(--ts-font-size-xs);
+  flex-shrink: 0;
+}
+
+.file-upload__file-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 2px;
+  color: var(--ts-color-text-tertiary);
+  border-radius: var(--ts-radius-sm);
+  flex-shrink: 0;
+}
+
+.file-upload__file-remove:hover {
+  color: var(--ts-color-danger-500);
+}
+
+.file-upload__capacity {
+  font-size: var(--ts-font-size-xs);
+  color: var(--ts-color-warning-600);
+  margin-block-start: var(--ts-spacing-1);
+}

--- a/src/components/file-upload/file-upload.spec.ts
+++ b/src/components/file-upload/file-upload.spec.ts
@@ -85,4 +85,86 @@ describe('ts-file-upload', () => {
     const input = page.root?.shadowRoot?.querySelector('input[type="file"]');
     expect(input?.getAttribute('name')).toBe('avatar');
   });
+
+  it('renders file list when files are selected', async () => {
+    const page = await newSpecPage({
+      components: [TsFileUpload],
+      html: '<ts-file-upload></ts-file-upload>',
+    });
+
+    const component = page.rootInstance as TsFileUpload;
+    component.selectedFiles = [
+      { name: 'test.txt', size: 5, type: 'text/plain' } as unknown as File,
+      { name: 'doc.pdf', size: 1024, type: 'application/pdf' } as unknown as File,
+    ];
+    await page.waitForChanges();
+
+    const fileList = page.root?.shadowRoot?.querySelector('.file-upload__list');
+    expect(fileList).not.toBeNull();
+
+    const items = page.root?.shadowRoot?.querySelectorAll('.file-upload__file');
+    expect(items?.length).toBe(2);
+
+    const firstName = items?.[0]?.querySelector('.file-upload__file-name');
+    expect(firstName?.textContent).toBe('test.txt');
+  });
+
+  it('does not render file list when showFileList is false', async () => {
+    const page = await newSpecPage({
+      components: [TsFileUpload],
+      html: '<ts-file-upload show-file-list="false"></ts-file-upload>',
+    });
+
+    const component = page.rootInstance as TsFileUpload;
+    component.selectedFiles = [
+      { name: 'test.txt', size: 5, type: 'text/plain' } as unknown as File,
+    ];
+    await page.waitForChanges();
+
+    const fileList = page.root?.shadowRoot?.querySelector('.file-upload__list');
+    expect(fileList).toBeNull();
+  });
+
+  it('limits files by maxFiles', async () => {
+    const page = await newSpecPage({
+      components: [TsFileUpload],
+      html: '<ts-file-upload max-files="2" multiple></ts-file-upload>',
+    });
+
+    const component = page.rootInstance as TsFileUpload;
+
+    component.selectedFiles = [
+      { name: 'a.txt', size: 1, type: 'text/plain' } as unknown as File,
+      { name: 'b.txt', size: 2, type: 'text/plain' } as unknown as File,
+    ];
+    await page.waitForChanges();
+
+    const capacity = page.root?.shadowRoot?.querySelector('.file-upload__capacity');
+    expect(capacity).not.toBeNull();
+    expect(capacity?.textContent).toContain('Maximum 2 files reached');
+  });
+
+  it('emits tsRemove when a file is removed', async () => {
+    const page = await newSpecPage({
+      components: [TsFileUpload],
+      html: '<ts-file-upload></ts-file-upload>',
+    });
+
+    const component = page.rootInstance as TsFileUpload;
+    const file1 = { name: 'test.txt', size: 5, type: 'text/plain' } as unknown as File;
+    const file2 = { name: 'doc.pdf', size: 1024, type: 'application/pdf' } as unknown as File;
+    component.selectedFiles = [file1, file2];
+    await page.waitForChanges();
+
+    const removeSpy = jest.fn();
+    page.root?.addEventListener('tsRemove', removeSpy);
+
+    const removeBtn = page.root?.shadowRoot?.querySelectorAll('.file-upload__file-remove')?.[0] as HTMLButtonElement;
+    removeBtn?.click();
+    await page.waitForChanges();
+
+    expect(removeSpy).toHaveBeenCalled();
+    expect(component.selectedFiles.length).toBe(1);
+    expect(component.selectedFiles[0].name).toBe('doc.pdf');
+  });
 });

--- a/src/components/file-upload/file-upload.stories.ts
+++ b/src/components/file-upload/file-upload.stories.ts
@@ -28,6 +28,14 @@ export default {
       control: 'text',
       description: 'Form field name.',
     },
+    maxFiles: {
+      control: 'number',
+      description: 'Maximum number of files allowed.',
+    },
+    showFileList: {
+      control: 'boolean',
+      description: 'Whether to show the file list below the dropzone.',
+    },
   },
 };
 
@@ -36,6 +44,8 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.accept !== undefined && args.accept !== '') attrs.push(`accept="${args.accept}"`);
   if (args.multiple) attrs.push('multiple');
   if (args.maxSize !== undefined) attrs.push(`max-size="${args.maxSize}"`);
+  if (args.maxFiles !== undefined) attrs.push(`max-files="${args.maxFiles}"`);
+  if (args.showFileList === false) attrs.push('show-file-list="false"');
   if (args.disabled) attrs.push('disabled');
   if (args.label !== undefined) attrs.push(`label="${args.label}"`);
   if (args.name !== undefined && args.name !== '') attrs.push(`name="${args.name}"`);
@@ -102,5 +112,30 @@ export const Composition = (): string => `
         <ts-button variant="primary">Upload Files</ts-button>
       </div>
     </div>
+  </div>
+`;
+
+export const WithFileList = (): string => `
+  <div style="max-width: 500px; font-family: sans-serif;">
+    <p style="margin: 0 0 8px; font-size: 14px; color: #666;">
+      Select files to see them listed below the dropzone. Each file shows its name, size, and a remove button.
+    </p>
+    <ts-file-upload
+      multiple
+      label="Drop files here to see the file list"
+    ></ts-file-upload>
+  </div>
+`;
+
+export const WithMaxFiles = (): string => `
+  <div style="max-width: 500px; font-family: sans-serif;">
+    <p style="margin: 0 0 8px; font-size: 14px; color: #666;">
+      Limited to 3 files maximum. A capacity message appears when the limit is reached.
+    </p>
+    <ts-file-upload
+      multiple
+      max-files="3"
+      label="Drop files here (max 3 files)"
+    ></ts-file-upload>
   </div>
 `;

--- a/src/components/file-upload/file-upload.tsx
+++ b/src/components/file-upload/file-upload.tsx
@@ -7,6 +7,9 @@ import type { EventEmitter } from '@stencil/core';
  * @part dropzone - The dropzone area.
  * @part label - The label text.
  * @part input - The hidden file input.
+ * @part file-list - The file list container.
+ * @part file-item - An individual file item.
+ * @part file-remove - The remove button for a file item.
  */
 @Component({
   tag: 'ts-file-upload',
@@ -27,6 +30,12 @@ export class TsFileUpload {
   /** Maximum file size in bytes. */
   @Prop() maxSize?: number;
 
+  /** Maximum number of files allowed. */
+  @Prop() maxFiles?: number;
+
+  /** Whether to show the file list below the dropzone. */
+  @Prop() showFileList = true;
+
   /** Whether the file upload is disabled. */
   @Prop({ reflect: true }) disabled = false;
 
@@ -39,8 +48,14 @@ export class TsFileUpload {
   /** Emitted when files are selected or dropped. */
   @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ files: File[] }>;
 
+  /** Emitted when a file is removed from the list. */
+  @Event({ eventName: 'tsRemove' }) tsRemove!: EventEmitter<{ file: File; files: File[] }>;
+
   /** Whether a drag operation is over the dropzone. */
   @State() isDragOver = false;
+
+  /** The currently selected files. */
+  @State() selectedFiles: File[] = [];
 
   private handleClick = (): void => {
     if (this.disabled) return;
@@ -60,7 +75,7 @@ export class TsFileUpload {
     if (input.files) {
       const files = this.validateFiles(Array.from(input.files));
       if (files.length > 0) {
-        this.tsChange.emit({ files });
+        this.storeFiles(files);
       }
     }
     // Reset input so the same file can be selected again
@@ -94,7 +109,7 @@ export class TsFileUpload {
     if (droppedFiles) {
       const files = this.validateFiles(Array.from(droppedFiles));
       if (files.length > 0) {
-        this.tsChange.emit({ files });
+        this.storeFiles(files);
       }
     }
   };
@@ -127,7 +142,43 @@ export class TsFileUpload {
       validFiles = [validFiles[0]];
     }
 
+    // Limit by maxFiles
+    if (this.maxFiles !== undefined && this.maxFiles > 0) {
+      const remaining = this.maxFiles - this.selectedFiles.length;
+      if (remaining <= 0) return [];
+      validFiles = validFiles.slice(0, remaining);
+    }
+
     return validFiles;
+  }
+
+  private storeFiles(files: File[]): void {
+    if (this.multiple) {
+      this.selectedFiles = [...this.selectedFiles, ...files];
+    } else {
+      this.selectedFiles = [...files];
+    }
+    this.tsChange.emit({ files: this.selectedFiles });
+  }
+
+  private handleRemoveFile = (index: number): void => {
+    const removed = this.selectedFiles[index];
+    this.selectedFiles = this.selectedFiles.filter((_, i) => i !== index);
+    this.tsRemove.emit({ file: removed, files: this.selectedFiles });
+    this.tsChange.emit({ files: this.selectedFiles });
+  };
+
+  private formatFileSize(bytes: number): string {
+    if (bytes >= 1073741824) {
+      return `${(bytes / 1073741824).toFixed(1)} GB`;
+    }
+    if (bytes >= 1048576) {
+      return `${(bytes / 1048576).toFixed(1)} MB`;
+    }
+    if (bytes >= 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${bytes} B`;
   }
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
@@ -174,6 +225,30 @@ export class TsFileUpload {
             onChange={this.handleFileChange}
           />
         </div>
+
+        {this.maxFiles !== undefined && this.selectedFiles.length >= this.maxFiles && (
+          <div class="file-upload__capacity">Maximum {this.maxFiles} files reached</div>
+        )}
+
+        {this.showFileList && this.selectedFiles.length > 0 && (
+          <div class="file-upload__list" part="file-list">
+            {this.selectedFiles.map((file, index) => (
+              <div class="file-upload__file" part="file-item" key={file.name + index}>
+                <span class="file-upload__file-name">{file.name}</span>
+                <span class="file-upload__file-size">{this.formatFileSize(file.size)}</span>
+                <button
+                  class="file-upload__file-remove"
+                  part="file-remove"
+                  type="button"
+                  aria-label={`Remove ${file.name}`}
+                  onClick={() => this.handleRemoveFile(index)}
+                >
+                  &times;
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </Host>
     );
   }


### PR DESCRIPTION
## Summary
- Show selected files below the dropzone with name, size, and remove button
- Add `maxFiles` prop to limit the number of selected files
- Add `tsRemove` event emitted when a file is removed from the list
- Add `showFileList` prop (default true) to control file list visibility

## Test plan
- [x] 12 unit tests pass (4 new)
- [x] Build passes
- [x] Lint passes (0 errors)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)