### PR TITLE
feat(dialog): add exit animations, prevent-close, and tsOpen event

### DIFF
--- a/src/components/dialog/dialog.css
+++ b/src/components/dialog/dialog.css
@@ -127,6 +127,25 @@
   }
 }
 
+/* ---- Exit Animations ---- */
+.dialog--closing.dialog__overlay {
+  animation: ts-dialog-overlay-exit var(--ts-transition-normal) ease-in forwards;
+}
+
+.dialog--closing.dialog__panel {
+  animation: ts-dialog-exit var(--ts-transition-normal) ease-in forwards;
+}
+
+@keyframes ts-dialog-exit {
+  from { opacity: 1; transform: scale(1); }
+  to { opacity: 0; transform: scale(0.95); }
+}
+
+@keyframes ts-dialog-overlay-exit {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+
 /* ---- Reduced motion ---- */
 @media (prefers-reduced-motion: reduce) {
   .dialog__overlay {

--- a/src/components/dialog/dialog.spec.ts
+++ b/src/components/dialog/dialog.spec.ts
@@ -2,6 +2,7 @@ import { newSpecPage } from '@stencil/core/testing';
 import { TsDialog } from './dialog';
 
 describe('ts-dialog', () => {
+
   it('does not render content when closed', async () => {
     const page = await newSpecPage({
       components: [TsDialog],
@@ -73,6 +74,10 @@ describe('ts-dialog', () => {
     closeBtn?.click();
     await page.waitForChanges();
 
+    // Wait for the exit animation fallback timer (250ms)
+    await new Promise(resolve => setTimeout(resolve, 300));
+    await page.waitForChanges();
+
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -84,5 +89,54 @@ describe('ts-dialog', () => {
 
     const panel = page.root?.shadowRoot?.querySelector('.dialog__panel');
     expect(panel?.classList.contains('dialog__panel--lg')).toBe(true);
+  });
+
+  it('emits tsOpen when opened', async () => {
+    const page = await newSpecPage({
+      components: [TsDialog],
+      html: '<ts-dialog heading="Test">Content</ts-dialog>',
+    });
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsOpen', spy);
+
+    page.root?.setAttribute('open', '');
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close immediately when preventClose is true', async () => {
+    const page = await newSpecPage({
+      components: [TsDialog],
+      html: '<ts-dialog open heading="Test" prevent-close>Content</ts-dialog>',
+    });
+
+    const closeSpy = jest.fn();
+    page.root?.addEventListener('tsClose', closeSpy);
+
+    const closeBtn = page.root?.shadowRoot?.querySelector<HTMLButtonElement>('.dialog__close');
+    closeBtn?.click();
+    await page.waitForChanges();
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(page.root?.open).toBe(true);
+  });
+
+  it('emits tsRequestClose with correct source when preventClose is true', async () => {
+    const page = await newSpecPage({
+      components: [TsDialog],
+      html: '<ts-dialog open heading="Test" prevent-close>Content</ts-dialog>',
+    });
+
+    const requestSpy = jest.fn();
+    page.root?.addEventListener('tsRequestClose', requestSpy);
+
+    const closeBtn = page.root?.shadowRoot?.querySelector<HTMLButtonElement>('.dialog__close');
+    closeBtn?.click();
+    await page.waitForChanges();
+
+    expect(requestSpy).toHaveBeenCalledTimes(1);
+    expect(requestSpy.mock.calls[0][0].detail).toEqual({ source: 'close-button' });
   });
 });

--- a/src/components/dialog/dialog.stories.ts
+++ b/src/components/dialog/dialog.stories.ts
@@ -148,3 +148,27 @@ export const FormDialog = (): string => `
     </div>
   </ts-dialog>
 `;
+
+export const PreventClose = (): string => `
+  <ts-button onclick="this.nextElementSibling.show()">Open Protected Dialog</ts-button>
+  <ts-dialog heading="Unsaved Changes" size="sm" prevent-close>
+    <p style="margin: 0; font-family: sans-serif; color: #555;">
+      You have unsaved changes. Are you sure you want to close this dialog?
+    </p>
+    <div slot="footer">
+      <ts-row gap="2" justify="end">
+        <ts-button appearance="outline" onclick="this.closest('ts-dialog').close()">Discard Changes</ts-button>
+        <ts-button variant="primary" onclick="this.closest('ts-dialog').close()">Save and Close</ts-button>
+      </ts-row>
+    </div>
+  </ts-dialog>
+  <script>
+    {
+      const dialog = document.currentScript.previousElementSibling;
+      dialog.addEventListener('tsRequestClose', (e) => {
+        const confirmed = window.confirm('You have unsaved changes. Discard them?');
+        if (confirmed) dialog.close();
+      });
+    }
+  </script>
+`;

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -22,6 +22,7 @@ export class TsDialog {
   @Element() hostEl!: HTMLElement;
 
   private dialogEl?: HTMLElement;
+  private overlayEl?: HTMLElement;
   private removeFocusTrap?: () => void;
   private previouslyFocused?: HTMLElement;
   private dialogId = generateId('ts-dialog');
@@ -38,11 +39,23 @@ export class TsDialog {
   /** Whether the dialog can be dismissed via close button, Escape, or overlay click. */
   @Prop() dismissible = true;
 
+  /** When true, close actions emit tsRequestClose instead of closing directly. */
+  @Prop() preventClose = false;
+
   /** Emitted when the dialog is closed. */
   @Event({ eventName: 'tsClose' }) tsClose!: EventEmitter<void>;
 
+  /** Emitted when the dialog is opened. */
+  @Event({ eventName: 'tsOpen' }) tsOpen!: EventEmitter<void>;
+
+  /** Emitted when a close is requested while preventClose is true. */
+  @Event({ eventName: 'tsRequestClose' }) tsRequestClose!: EventEmitter<{ source: 'overlay' | 'escape' | 'close-button' }>;
+
   /** Internal animation state. */
   @State() isAnimating = false;
+
+  /** Whether the dialog is playing the closing animation. */
+  @State() isClosing = false;
 
   @Watch('open')
   handleOpenChange(isOpen: boolean): void {
@@ -68,8 +81,11 @@ export class TsDialog {
   private openDialog(): void {
     this.previouslyFocused = document.activeElement as HTMLElement;
     this.isAnimating = true;
+    this.isClosing = false;
 
     document.body.style.overflow = 'hidden';
+
+    this.tsOpen.emit();
 
     requestAnimationFrame(() => {
       if (this.dialogEl) {
@@ -80,6 +96,33 @@ export class TsDialog {
   }
 
   private closeDialog(): void {
+    this.isClosing = true;
+
+    let finished = false;
+    const finish = (): void => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(fallbackTimer);
+      this.overlayEl?.removeEventListener('animationend', onAnimationEnd);
+      this.finishClose();
+    };
+
+    const onAnimationEnd = (): void => {
+      finish();
+    };
+
+    // Fallback timer in case animationend never fires (e.g., reduced motion, test env)
+    const fallbackTimer = setTimeout(finish, 250);
+
+    if (this.overlayEl) {
+      this.overlayEl.addEventListener('animationend', onAnimationEnd);
+    } else {
+      finish();
+    }
+  }
+
+  private finishClose(): void {
+    this.isClosing = false;
     this.isAnimating = false;
     this.tsClose.emit();
 
@@ -89,6 +132,14 @@ export class TsDialog {
     this.previouslyFocused?.focus();
   }
 
+  private requestCloseOrClose(source: 'overlay' | 'escape' | 'close-button'): void {
+    if (this.preventClose) {
+      this.tsRequestClose.emit({ source });
+    } else {
+      this.close();
+    }
+  }
+
   disconnectedCallback(): void {
     this.removeFocusTrap?.();
     document.body.style.overflow = '';
@@ -96,7 +147,7 @@ export class TsDialog {
 
   private handleOverlayClick = (): void => {
     if (this.dismissible) {
-      this.close();
+      this.requestCloseOrClose('overlay');
     }
   };
 
@@ -107,17 +158,17 @@ export class TsDialog {
   private handleKeydown = (event: KeyboardEvent): void => {
     if (event.key === 'Escape' && this.dismissible) {
       event.stopPropagation();
-      this.close();
+      this.requestCloseOrClose('escape');
     }
   };
 
   private handleCloseClick = (): void => {
-    this.close();
+    this.requestCloseOrClose('close-button');
   };
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
-    if (!this.open) return null;
+    if (!this.open && !this.isClosing) return null;
 
     const headingId = `${this.dialogId}-heading`;
 
@@ -129,12 +180,21 @@ export class TsDialog {
         }}
         onKeyDown={this.handleKeydown}
       >
-        <div class="dialog__overlay" part="overlay" onClick={this.handleOverlayClick}>
+        <div
+          ref={(el) => (this.overlayEl = el)}
+          class={{
+            'dialog__overlay': true,
+            'dialog--closing': this.isClosing,
+          }}
+          part="overlay"
+          onClick={this.handleOverlayClick}
+        >
           <div
             ref={(el) => (this.dialogEl = el)}
             class={{
               'dialog__panel': true,
               [`dialog__panel--${this.size}`]: true,
+              'dialog--closing': this.isClosing,
             }}
             part="dialog"
             role="dialog"


### PR DESCRIPTION
## Summary
- Add exit animation (fade + scale down) when dialog closes
- Add `preventClose` prop with `tsRequestClose` event for confirmation flows
- Add `tsOpen` event emitted when dialog opens

## Test plan
- [x] 10 unit tests pass (3 new)
- [x] Build passes

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)