### PR TITLE
feat(nav): add expandable items, badges, and dividers

### DIFF
--- a/src/components/nav/nav-divider.css
+++ b/src/components/nav/nav-divider.css
@@ -1,0 +1,15 @@
+/* ==========================================================================
+   ts-nav-divider — Shadow DOM Scoped Styles
+   ========================================================================== */
+
+:host {
+  display: block;
+}
+
+.nav-divider {
+  list-style: none;
+  margin: var(--ts-spacing-2) 0;
+  padding: 0;
+  border: none;
+  border-block-start: 1px solid var(--ts-color-border-secondary);
+}

--- a/src/components/nav/nav-divider.stories.ts
+++ b/src/components/nav/nav-divider.stories.ts
@@ -1,0 +1,4 @@
+// Stories for ts-nav-divider are in the parent component's stories file
+// This file exists only to prevent auto-generation
+
+export default { title: 'Internal/nav-divider', tags: ['!autodocs'] };

--- a/src/components/nav/nav-divider.tsx
+++ b/src/components/nav/nav-divider.tsx
@@ -1,0 +1,22 @@
+import { Component, h, Host } from '@stencil/core';
+
+/**
+ * A visual separator for nav items.
+ *
+ * @part divider - The separator element.
+ */
+@Component({
+  tag: 'ts-nav-divider',
+  styleUrl: 'nav-divider.css',
+  shadow: true,
+})
+export class TsNavDivider {
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    return (
+      <Host>
+        <li role="separator" class="nav-divider" part="divider" />
+      </Host>
+    );
+  }
+}

--- a/src/components/nav/nav-item.css
+++ b/src/components/nav/nav-item.css
@@ -71,3 +71,39 @@
   align-items: center;
   white-space: nowrap;
 }
+
+/* ---- Expandable ---- */
+.nav-item__chevron {
+  display: inline-flex;
+  margin-inline-start: auto;
+  transition: transform var(--ts-transition-fast);
+}
+
+:host([expanded]) .nav-item__chevron {
+  transform: rotate(90deg);
+}
+
+.nav-item__children {
+  display: none;
+  padding-inline-start: var(--ts-spacing-4);
+}
+
+:host([expanded]) .nav-item__children {
+  display: block;
+}
+
+/* ---- Badge ---- */
+.nav-item__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-inline-start: auto;
+  min-inline-size: 1.25rem;
+  padding-inline: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  font-weight: var(--ts-font-weight-semi);
+  line-height: 1.25rem;
+  border-radius: var(--ts-radius-full);
+  background-color: var(--ts-color-danger-500);
+  color: var(--ts-color-text-on-primary);
+}

--- a/src/components/nav/nav-item.tsx
+++ b/src/components/nav/nav-item.tsx
@@ -3,11 +3,15 @@ import type { EventEmitter } from '@stencil/core';
 
 /**
  * @slot - Default slot for label text.
+ * @slot children - Slot for nested nav items when expandable.
  *
  * @part item - The list item wrapper.
  * @part link - The anchor or button element.
  * @part icon - The icon wrapper.
  * @part label - The label wrapper.
+ * @part badge - The badge element.
+ * @part chevron - The expand/collapse chevron indicator.
+ * @part children - The nested children wrapper.
  */
 @Component({
   tag: 'ts-nav-item',
@@ -27,6 +31,15 @@ export class TsNavItem {
   /** Lucide icon name to display. */
   @Prop() icon?: string;
 
+  /** Whether this item contains expandable nested items. */
+  @Prop({ reflect: true }) expandable = false;
+
+  /** Whether the nested items are currently visible. */
+  @Prop({ reflect: true, mutable: true }) expanded = false;
+
+  /** Badge text or count to display after the label. */
+  @Prop() badge?: string;
+
   /** Emitted when the nav item is selected. */
   @Event({ eventName: 'tsSelect' }) tsSelect!: EventEmitter<void>;
 
@@ -36,15 +49,21 @@ export class TsNavItem {
       event.stopPropagation();
       return;
     }
+    if (this.expandable) {
+      event.preventDefault();
+      this.expanded = !this.expanded;
+      return;
+    }
     this.tsSelect.emit();
   };
 
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
-    const Tag = this.href ? 'a' : 'button';
-    const attrs = this.href
-      ? { href: this.disabled ? undefined : this.href }
-      : { type: 'button' as const, disabled: this.disabled };
+    const Tag = this.href && !this.expandable ? 'a' : 'button';
+    const attrs =
+      Tag === 'a'
+        ? { href: this.disabled ? undefined : this.href }
+        : { type: 'button' as const, disabled: this.disabled };
 
     return (
       <Host
@@ -52,6 +71,8 @@ export class TsNavItem {
           'ts-nav-item': true,
           'ts-nav-item--active': this.active,
           'ts-nav-item--disabled': this.disabled,
+          'ts-nav-item--expandable': this.expandable,
+          'ts-nav-item--expanded': this.expanded,
         }}
       >
         <li class="nav-item__wrapper" part="item" role="listitem">
@@ -61,6 +82,7 @@ export class TsNavItem {
             part="link"
             aria-current={this.active ? 'page' : undefined}
             aria-disabled={this.disabled ? 'true' : undefined}
+            aria-expanded={this.expandable ? String(this.expanded) : undefined}
             onClick={this.handleClick}
           >
             {this.icon && (
@@ -71,7 +93,22 @@ export class TsNavItem {
             <span class="nav-item__label" part="label">
               <slot />
             </span>
+            {this.badge !== undefined && !this.expandable && (
+              <span class="nav-item__badge" part="badge">
+                {this.badge}
+              </span>
+            )}
+            {this.expandable && (
+              <span class="nav-item__chevron" part="chevron" aria-hidden="true">
+                <ts-icon name="chevron-right" size="sm" />
+              </span>
+            )}
           </Tag>
+          {this.expandable && (
+            <div class="nav-item__children" part="children" role="group">
+              <slot name="children" />
+            </div>
+          )}
         </li>
       </Host>
     );

--- a/src/components/nav/nav.spec.ts
+++ b/src/components/nav/nav.spec.ts
@@ -1,6 +1,7 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { TsNav } from './nav';
 import { TsNavItem } from './nav-item';
+import { TsNavDivider } from './nav-divider';
 
 describe('ts-nav', () => {
   it('renders with default props', async () => {
@@ -133,5 +134,68 @@ describe('ts-nav-item', () => {
     button?.click();
 
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('renders chevron when expandable', async () => {
+    const page = await newSpecPage({
+      components: [TsNavItem],
+      html: '<ts-nav-item expandable>Settings</ts-nav-item>',
+    });
+
+    const chevron = page.root?.shadowRoot?.querySelector('.nav-item__chevron');
+    expect(chevron).not.toBeNull();
+  });
+
+  it('toggles expanded state on click', async () => {
+    const page = await newSpecPage({
+      components: [TsNavItem],
+      html: '<ts-nav-item expandable>Settings</ts-nav-item>',
+    });
+
+    expect(page.root?.expanded).toBe(false);
+
+    const button = page.root?.shadowRoot?.querySelector('button');
+    button?.click();
+    await page.waitForChanges();
+
+    expect(page.root?.expanded).toBe(true);
+
+    button?.click();
+    await page.waitForChanges();
+
+    expect(page.root?.expanded).toBe(false);
+  });
+
+  it('renders badge when prop is set', async () => {
+    const page = await newSpecPage({
+      components: [TsNavItem],
+      html: '<ts-nav-item badge="5">Inbox</ts-nav-item>',
+    });
+
+    const badge = page.root?.shadowRoot?.querySelector('.nav-item__badge');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('5');
+  });
+
+  it('does not render badge when prop is not set', async () => {
+    const page = await newSpecPage({
+      components: [TsNavItem],
+      html: '<ts-nav-item>Home</ts-nav-item>',
+    });
+
+    const badge = page.root?.shadowRoot?.querySelector('.nav-item__badge');
+    expect(badge).toBeNull();
+  });
+});
+
+describe('ts-nav-divider', () => {
+  it('renders a separator', async () => {
+    const page = await newSpecPage({
+      components: [TsNavDivider],
+      html: '<ts-nav-divider></ts-nav-divider>',
+    });
+
+    const separator = page.root?.shadowRoot?.querySelector('[role="separator"]');
+    expect(separator).not.toBeNull();
   });
 });

--- a/src/components/nav/nav.stories.ts
+++ b/src/components/nav/nav.stories.ts
@@ -89,6 +89,41 @@ export const States = (): string => `
   </div>
 `;
 
+export const NestedItems = (): string => `
+  <div style="width: 240px;">
+    <ts-nav variant="sidebar">
+      <ts-nav-item icon="layout-dashboard" active>Dashboard</ts-nav-item>
+      <ts-nav-item icon="settings" expandable expanded>
+        Settings
+        <ts-nav-item slot="children">Account</ts-nav-item>
+        <ts-nav-item slot="children">Security</ts-nav-item>
+        <ts-nav-item slot="children">Notifications</ts-nav-item>
+      </ts-nav-item>
+      <ts-nav-item icon="file-text" expandable>
+        Documents
+        <ts-nav-item slot="children">Recent</ts-nav-item>
+        <ts-nav-item slot="children">Shared</ts-nav-item>
+        <ts-nav-item slot="children">Archived</ts-nav-item>
+      </ts-nav-item>
+      <ts-nav-item icon="bar-chart-2">Reports</ts-nav-item>
+    </ts-nav>
+  </div>
+`;
+
+export const WithBadges = (): string => `
+  <div style="width: 240px;">
+    <ts-nav variant="sidebar">
+      <ts-nav-item icon="layout-dashboard" active>Dashboard</ts-nav-item>
+      <ts-nav-item icon="inbox" badge="12">Inbox</ts-nav-item>
+      <ts-nav-item icon="bell" badge="3">Notifications</ts-nav-item>
+      <ts-nav-item icon="users" badge="99+">Users</ts-nav-item>
+      <ts-nav-divider></ts-nav-divider>
+      <ts-nav-item icon="settings">Settings</ts-nav-item>
+      <ts-nav-item icon="log-out">Sign Out</ts-nav-item>
+    </ts-nav>
+  </div>
+`;
+
 export const Composition = (): string => `
   <div style="display: flex; border: 1px solid #e2e8f0; border-radius: 8px; height: 400px; overflow: hidden;">
     <div style="width: 240px; border-right: 1px solid #e2e8f0; padding: 16px 0; background: #f8fafc;">
@@ -98,6 +133,7 @@ export const Composition = (): string => `
         <ts-nav-item icon="users" href="#">Users</ts-nav-item>
         <ts-nav-item icon="file-text" href="#">Documents</ts-nav-item>
         <ts-nav-item icon="bar-chart-2" href="#">Analytics</ts-nav-item>
+        <ts-nav-divider></ts-nav-divider>
         <ts-nav-item icon="settings" href="#">Settings</ts-nav-item>
       </ts-nav>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { TsBanner } from './components/banner/banner';
 export { TsDrawer } from './components/drawer/drawer';
 export { TsNav } from './components/nav/nav';
 export { TsNavItem } from './components/nav/nav-item';
+export { TsNavDivider } from './components/nav/nav-divider';
 export { TsDatePicker } from './components/date-picker/date-picker';
 export { TsFileUpload } from './components/file-upload/file-upload';
 export { TsStepper } from './components/stepper/stepper';


### PR DESCRIPTION
## Summary
- Add `expandable`/`expanded` props to `ts-nav-item` for nested navigation groups
- Add `badge` prop for notification count indicators
- Add `ts-nav-divider` component for section separators

## Test plan
- [x] 17 unit tests pass
- [x] Build passes

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)