### PR TITLE
feat(a11y): add forced-colors CSS overrides for High Contrast Mode

### DIFF
--- a/src/components/banner/banner.css
+++ b/src/components/banner/banner.css
@@ -127,3 +127,9 @@
   box-shadow: var(--ts-focus-ring);
   opacity: 1;
 }
+
+@media (forced-colors: active) {
+  .banner__base {
+    border: 1px solid CanvasText;
+  }
+}

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -260,6 +260,20 @@
 }
 
 /* ---- Reduced motion ---- */
+@media (forced-colors: active) {
+  .button__native {
+    border: 1px solid ButtonText;
+  }
+  .button__native:disabled,
+  .button__native[aria-disabled="true"] {
+    border-color: GrayText;
+    color: GrayText;
+  }
+  .button__native:focus-visible {
+    outline: 2px solid Highlight;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .button__native {
     transition-duration: 0.01ms !important;

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -105,3 +105,9 @@
 :host([padding="lg"]) .card__header,
 :host([padding="lg"]) .card__body,
 :host([padding="lg"]) .card__footer { padding: var(--ts-spacing-6); }
+
+@media (forced-colors: active) {
+  .card__base {
+    border: 1px solid CanvasText;
+  }
+}

--- a/src/components/checkbox/checkbox.css
+++ b/src/components/checkbox/checkbox.css
@@ -113,3 +113,12 @@
   line-height: var(--ts-line-height-normal);
   user-select: none;
 }
+
+@media (forced-colors: active) {
+  .checkbox__control {
+    border: 2px solid ButtonText;
+  }
+  :host([disabled]) .checkbox__control {
+    border-color: GrayText;
+  }
+}

--- a/src/components/chip/chip.css
+++ b/src/components/chip/chip.css
@@ -208,3 +208,9 @@
   cursor: not-allowed;
   pointer-events: none;
 }
+
+@media (forced-colors: active) {
+  .chip__base {
+    border: 1px solid ButtonText;
+  }
+}

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -197,3 +197,15 @@
 .input__counter--danger {
   color: var(--ts-color-danger-500);
 }
+
+@media (forced-colors: active) {
+  .input__wrapper {
+    border: 1px solid ButtonText;
+  }
+  .input__wrapper--disabled {
+    border-color: GrayText;
+  }
+  .input__wrapper--focused {
+    outline: 2px solid Highlight;
+  }
+}

--- a/src/components/radio/radio.css
+++ b/src/components/radio/radio.css
@@ -108,3 +108,12 @@
   line-height: var(--ts-line-height-normal);
   user-select: none;
 }
+
+@media (forced-colors: active) {
+  .radio__control {
+    border: 2px solid ButtonText;
+  }
+  :host([disabled]) .radio__control {
+    border-color: GrayText;
+  }
+}

--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -215,3 +215,15 @@
   color: var(--ts-color-danger-600);
   font-weight: var(--ts-font-weight-medium);
 }
+
+@media (forced-colors: active) {
+  .select__trigger {
+    border: 1px solid ButtonText;
+  }
+  .select__trigger--disabled {
+    border-color: GrayText;
+  }
+  .select__trigger:focus-visible {
+    outline: 2px solid Highlight;
+  }
+}

--- a/src/components/tabs/tabs.css
+++ b/src/components/tabs/tabs.css
@@ -200,3 +200,9 @@
   overflow-x: hidden;
   overflow-y: auto;
 }
+
+@media (forced-colors: active) {
+  .tabs__tab--active {
+    border-color: Highlight;
+  }
+}

--- a/src/components/toggle/toggle.css
+++ b/src/components/toggle/toggle.css
@@ -97,3 +97,12 @@
 :host([size="lg"]) .toggle__label {
   font-size: var(--ts-font-size-md);
 }
+
+@media (forced-colors: active) {
+  .toggle__track {
+    border: 2px solid ButtonText;
+  }
+  :host(.ts-toggle--disabled) .toggle__track {
+    border-color: GrayText;
+  }
+}


### PR DESCRIPTION
## Summary
Add `@media (forced-colors: active)` rules to 10 components (Button, Input, Select, Card, Chip, Checkbox, Radio, Tabs, Toggle, Banner) ensuring borders, disabled states, and focus indicators remain visible in Windows High Contrast Mode.

## Test plan
- [x] Build passes
- [x] CSS-only changes — no behavioral tests needed

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)