### PR TITLE
feat: add page header component

### DIFF
--- a/src/components/page-header/page-header.css
+++ b/src/components/page-header/page-header.css
@@ -1,0 +1,54 @@
+:host {
+  display: block;
+  font-family: var(--ts-font-family-base);
+}
+
+.page-header__main {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--ts-spacing-4);
+}
+
+.page-header__content {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--ts-spacing-2);
+}
+
+.page-header__heading {
+  margin: 0;
+  font-size: var(--ts-font-size-xl);
+  font-weight: var(--ts-font-weight-bold);
+  color: var(--ts-color-text-primary);
+}
+
+.page-header__description {
+  margin: var(--ts-spacing-1) 0 0;
+  font-size: var(--ts-font-size-md);
+  color: var(--ts-color-text-secondary);
+}
+
+.page-header__actions {
+  display: flex;
+  gap: var(--ts-spacing-2);
+  flex-shrink: 0;
+}
+
+.page-header__back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ts-color-text-secondary);
+  text-decoration: none;
+  margin-inline-end: var(--ts-spacing-2);
+  padding: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  margin-block-start: var(--ts-spacing-1);
+}
+
+.page-header__back:hover {
+  color: var(--ts-color-text-primary);
+}

--- a/src/components/page-header/page-header.e2e.ts
+++ b/src/components/page-header/page-header.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-page-header e2e', () => {
+  it('renders on the page', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-page-header heading="Dashboard"></ts-page-header>');
+
+    const element = await page.find('ts-page-header');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/page-header/page-header.spec.ts
+++ b/src/components/page-header/page-header.spec.ts
@@ -1,0 +1,99 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsPageHeader } from './page-header';
+
+describe('ts-page-header', () => {
+  it('renders with heading', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: '<ts-page-header heading="Dashboard"></ts-page-header>',
+    });
+
+    const heading = page.root?.shadowRoot?.querySelector('.page-header__heading');
+    expect(heading).not.toBeNull();
+    expect(heading?.textContent).toBe('Dashboard');
+  });
+
+  it('renders description when provided', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: '<ts-page-header heading="Settings" description="Manage your account settings"></ts-page-header>',
+    });
+
+    const description = page.root?.shadowRoot?.querySelector('.page-header__description');
+    expect(description).not.toBeNull();
+    expect(description?.textContent).toBe('Manage your account settings');
+  });
+
+  it('does not render description when not provided', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: '<ts-page-header heading="Dashboard"></ts-page-header>',
+    });
+
+    const description = page.root?.shadowRoot?.querySelector('.page-header__description');
+    expect(description).toBeNull();
+  });
+
+  it('renders back link when backHref is provided', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: '<ts-page-header heading="Details" back-href="/list"></ts-page-header>',
+    });
+
+    const backLink = page.root?.shadowRoot?.querySelector('a.page-header__back');
+    expect(backLink).not.toBeNull();
+    expect(backLink?.getAttribute('href')).toBe('/list');
+  });
+
+  it('does not render back element when backHref is not provided', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: '<ts-page-header heading="Dashboard"></ts-page-header>',
+    });
+
+    const backLink = page.root?.shadowRoot?.querySelector('.page-header__back');
+    expect(backLink).toBeNull();
+  });
+
+  it('renders breadcrumb slot', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: `
+        <ts-page-header heading="Dashboard">
+          <nav slot="breadcrumb">Home / Dashboard</nav>
+        </ts-page-header>
+      `,
+    });
+
+    const slotted = page.root?.querySelector('[slot="breadcrumb"]');
+    expect(slotted).not.toBeNull();
+  });
+
+  it('renders actions slot', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: `
+        <ts-page-header heading="Dashboard">
+          <button slot="actions">Save</button>
+        </ts-page-header>
+      `,
+    });
+
+    const slotted = page.root?.querySelector('[slot="actions"]');
+    expect(slotted).not.toBeNull();
+  });
+
+  it('renders tabs slot', async () => {
+    const page = await newSpecPage({
+      components: [TsPageHeader],
+      html: `
+        <ts-page-header heading="Dashboard">
+          <div slot="tabs">Tab content</div>
+        </ts-page-header>
+      `,
+    });
+
+    const slotted = page.root?.querySelector('[slot="tabs"]');
+    expect(slotted).not.toBeNull();
+  });
+});

--- a/src/components/page-header/page-header.stories.ts
+++ b/src/components/page-header/page-header.stories.ts
@@ -1,0 +1,89 @@
+// Hand-written stories for ts-page-header
+
+export default {
+  title: 'Components/Page Header',
+  tags: ['autodocs'],
+  argTypes: {
+    heading: { control: 'text', description: 'The page heading text.' },
+    description: { control: 'text', description: 'Optional description text below the heading.' },
+    backHref: { control: 'text', description: 'Optional URL for the back navigation link.' },
+  },
+};
+
+const Template = (args: Record<string, unknown>): string => {
+  const attrs: string[] = [];
+  if (args.heading) attrs.push(`heading="${args.heading}"`);
+  if (args.description) attrs.push(`description="${args.description}"`);
+  if (args.backHref) attrs.push(`back-href="${args.backHref}"`);
+
+  return `<ts-page-header ${attrs.join(' ')}></ts-page-header>`;
+};
+
+export const Default = Object.assign(Template.bind({}) as typeof Template & { args: Record<string, unknown> }, {
+  args: {
+    heading: 'Dashboard',
+    description: 'Overview of your workspace activity and metrics.',
+  },
+});
+
+export const WithBreadcrumb = (): string => `
+  <ts-page-header heading="Project Settings" description="Configure your project preferences and integrations.">
+    <ts-breadcrumb slot="breadcrumb">
+      <ts-breadcrumb-item href="/">Home</ts-breadcrumb-item>
+      <ts-breadcrumb-item href="/projects">Projects</ts-breadcrumb-item>
+      <ts-breadcrumb-item>Settings</ts-breadcrumb-item>
+    </ts-breadcrumb>
+  </ts-page-header>
+`;
+
+export const WithActions = (): string => `
+  <ts-page-header heading="Team Members" description="Manage who has access to this workspace.">
+    <div slot="actions" style="display: flex; gap: 8px;">
+      <ts-button variant="neutral" appearance="outline">
+        <ts-icon name="download" slot="prefix"></ts-icon>
+        Export
+      </ts-button>
+      <ts-button variant="primary">
+        <ts-icon name="plus" slot="prefix"></ts-icon>
+        Invite Member
+      </ts-button>
+    </div>
+  </ts-page-header>
+`;
+
+export const WithBackLink = (): string => `
+  <ts-page-header
+    heading="Invoice #1042"
+    description="Created on March 15, 2026"
+    back-href="/invoices"
+  ></ts-page-header>
+`;
+
+export const FullFeatured = (): string => `
+  <ts-page-header
+    heading="Analytics"
+    description="Track performance across all your campaigns."
+    back-href="/home"
+  >
+    <ts-breadcrumb slot="breadcrumb">
+      <ts-breadcrumb-item href="/">Home</ts-breadcrumb-item>
+      <ts-breadcrumb-item href="/marketing">Marketing</ts-breadcrumb-item>
+      <ts-breadcrumb-item>Analytics</ts-breadcrumb-item>
+    </ts-breadcrumb>
+    <div slot="actions" style="display: flex; gap: 8px;">
+      <ts-button variant="neutral" appearance="outline">
+        <ts-icon name="calendar" slot="prefix"></ts-icon>
+        Date Range
+      </ts-button>
+      <ts-button variant="primary">
+        <ts-icon name="download" slot="prefix"></ts-icon>
+        Export Report
+      </ts-button>
+    </div>
+    <ts-tabs slot="tabs">
+      <ts-tab-panel label="Overview">Overview content</ts-tab-panel>
+      <ts-tab-panel label="Traffic">Traffic content</ts-tab-panel>
+      <ts-tab-panel label="Conversions">Conversions content</ts-tab-panel>
+    </ts-tabs>
+  </ts-page-header>
+`;

--- a/src/components/page-header/page-header.tsx
+++ b/src/components/page-header/page-header.tsx
@@ -1,0 +1,71 @@
+import { Component, Prop, Event, h, Host } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
+
+/**
+ * @slot breadcrumb - Breadcrumb navigation displayed above the heading.
+ * @slot actions - Right-aligned action buttons.
+ * @slot tabs - Tab navigation displayed below the description.
+ *
+ * @part heading - The h1 heading element.
+ * @part description - The description paragraph.
+ * @part back - The back navigation link.
+ */
+@Component({
+  tag: 'ts-page-header',
+  styleUrl: 'page-header.css',
+  shadow: true,
+})
+export class TsPageHeader {
+  /** The page heading text. */
+  @Prop() heading!: string;
+
+  /** Optional description text displayed below the heading. */
+  @Prop() description?: string;
+
+  /** Optional URL for the back navigation link. When set, renders a back arrow link. */
+  @Prop() backHref?: string;
+
+  /** Emitted when the back link is clicked. */
+  @Event({ eventName: 'tsBack' }) tsBack!: EventEmitter<void>;
+
+  private handleBackClick = (): void => {
+    this.tsBack.emit();
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    return (
+      <Host>
+        <slot name="breadcrumb" />
+        <div class="page-header__main">
+          <div class="page-header__content">
+            {this.backHref && (
+              <a
+                class="page-header__back"
+                part="back"
+                href={this.backHref}
+                onClick={this.handleBackClick}
+              >
+                <ts-icon name="arrow-left" size="sm"></ts-icon>
+              </a>
+            )}
+            <div>
+              <h1 class="page-header__heading" part="heading">
+                {this.heading}
+              </h1>
+              {this.description && (
+                <p class="page-header__description" part="description">
+                  {this.description}
+                </p>
+              )}
+            </div>
+          </div>
+          <div class="page-header__actions">
+            <slot name="actions" />
+          </div>
+        </div>
+        <slot name="tabs" />
+      </Host>
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,4 @@ export { TsCheckboxGroup } from './components/checkbox-group/checkbox-group';
 export { TsNumberInput } from './components/number-input/number-input';
 export { TsTagInput } from './components/tag-input/tag-input';
 export { TsScrollArea } from './components/scroll-area/scroll-area';
+export { TsPageHeader } from './components/page-header/page-header';


### PR DESCRIPTION
## Summary
New `ts-page-header` component with heading, description, breadcrumb slot, actions slot, tabs slot, and optional back navigation.

## Test plan
- [x] 8 unit tests pass
- [x] Build passes

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)