### PR TITLE
feat(select): add search/filter, clearable, and aria-activedescendant

### DIFF
--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -194,6 +194,59 @@
   border-radius: var(--ts-radius-lg);
 }
 
+/* ---- Clear button ---- */
+.select__clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--ts-color-text-tertiary);
+  cursor: pointer;
+  border-radius: var(--ts-radius-sm);
+  transition: color var(--ts-transition-fast);
+}
+
+.select__clear:hover {
+  color: var(--ts-color-text-primary);
+}
+
+.select__clear svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ---- Search input ---- */
+.select__search {
+  display: block;
+  width: 100%;
+  padding: var(--ts-spacing-2) var(--ts-spacing-3);
+  border: none;
+  border-block-end: 1px solid var(--ts-color-border-default);
+  background: transparent;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--ts-color-text-primary);
+  outline: none;
+  box-sizing: border-box;
+}
+
+.select__search::placeholder {
+  color: var(--ts-color-text-tertiary);
+}
+
+/* ---- No results ---- */
+.select__no-results {
+  padding: var(--ts-spacing-2) var(--ts-spacing-3);
+  color: var(--ts-color-text-tertiary);
+  font-size: inherit;
+  text-align: center;
+}
+
 /* ---- Hidden slot ---- */
 .select__hidden-slot {
   display: none;

--- a/src/components/select/select.spec.ts
+++ b/src/components/select/select.spec.ts
@@ -181,4 +181,111 @@ describe('ts-select', () => {
     const listbox = page.root?.shadowRoot?.querySelector('[role="listbox"]');
     expect(listbox?.getAttribute('aria-multiselectable')).toBe('true');
   });
+
+  it('renders search input when searchable and open', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select searchable>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-select>`,
+    });
+
+    const select = page.rootInstance as TsSelect;
+    (select as unknown as { isOpen: boolean }).isOpen = true;
+    await page.waitForChanges();
+
+    const searchInput = page.root?.shadowRoot?.querySelector('.select__search');
+    expect(searchInput).not.toBeNull();
+  });
+
+  it('filters options by search query', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select searchable>
+        <option value="a">Apple</option>
+        <option value="b">Banana</option>
+        <option value="c">Cherry</option>
+      </ts-select>`,
+    });
+
+    const select = page.rootInstance as TsSelect;
+    (select as unknown as { isOpen: boolean }).isOpen = true;
+    (select as unknown as { searchQuery: string }).searchQuery = 'ban';
+    await page.waitForChanges();
+
+    const options = page.root?.shadowRoot?.querySelectorAll('.select__option');
+    expect(options?.length).toBe(1);
+    expect(options?.[0].textContent).toContain('Banana');
+  });
+
+  it('renders clear button when clearable and has value', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select clearable value="a">
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-select>`,
+    });
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.select__clear');
+    expect(clearBtn).not.toBeNull();
+  });
+
+  it('does not render clear button when clearable but no value', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select clearable>
+        <option value="a">Option A</option>
+      </ts-select>`,
+    });
+
+    const clearBtn = page.root?.shadowRoot?.querySelector('.select__clear');
+    expect(clearBtn).toBeNull();
+  });
+
+  it('sets aria-activedescendant on trigger when open', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-select>`,
+    });
+
+    const select = page.rootInstance as TsSelect;
+    (select as unknown as { isOpen: boolean }).isOpen = true;
+    (select as unknown as { focusedIndex: number }).focusedIndex = 0;
+    await page.waitForChanges();
+
+    const trigger = page.root?.shadowRoot?.querySelector('.select__trigger');
+    const activedescendant = trigger?.getAttribute('aria-activedescendant');
+    expect(activedescendant).toContain('-option-0');
+  });
+
+  it('sets aria-describedby linking to help text', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select help-text="Pick one">
+        <option value="a">Option A</option>
+      </ts-select>`,
+    });
+
+    const trigger = page.root?.shadowRoot?.querySelector('.select__trigger');
+    const describedBy = trigger?.getAttribute('aria-describedby');
+    expect(describedBy).toContain('-help');
+  });
+
+  it('sets aria-describedby linking to error text', async () => {
+    const page = await newSpecPage({
+      components: [TsSelect],
+      html: `<ts-select error error-message="Required">
+        <option value="a">Option A</option>
+      </ts-select>`,
+    });
+
+    const trigger = page.root?.shadowRoot?.querySelector('.select__trigger');
+    const describedBy = trigger?.getAttribute('aria-describedby');
+    expect(describedBy).toContain('-error');
+  });
 });

--- a/src/components/select/select.stories.ts
+++ b/src/components/select/select.stories.ts
@@ -150,3 +150,38 @@ export const Multiple = (): string => `
     </ts-select>
   </div>
 `;
+
+export const Searchable = (): string => `
+  <div style="max-width: 320px;">
+    <ts-select searchable label="Country" placeholder="Search for a country" help-text="Type to filter the list.">
+      <option value="us">United States</option>
+      <option value="uk">United Kingdom</option>
+      <option value="ca">Canada</option>
+      <option value="au">Australia</option>
+      <option value="de">Germany</option>
+      <option value="fr">France</option>
+      <option value="jp">Japan</option>
+      <option value="br">Brazil</option>
+      <option value="in">India</option>
+      <option value="mx">Mexico</option>
+    </ts-select>
+  </div>
+`;
+
+export const Clearable = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+    <ts-select clearable label="Timezone" placeholder="Select a timezone" value="utc" help-text="Click the x to clear.">
+      <option value="utc">UTC</option>
+      <option value="est">Eastern Time</option>
+      <option value="cst">Central Time</option>
+      <option value="pst">Pacific Time</option>
+    </ts-select>
+    <ts-select clearable searchable label="Language" placeholder="Search and select a language" value="en">
+      <option value="en">English</option>
+      <option value="es">Spanish</option>
+      <option value="fr">French</option>
+      <option value="de">German</option>
+      <option value="ja">Japanese</option>
+    </ts-select>
+  </div>
+`;

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -30,6 +30,7 @@ export class TsSelect {
 
   private inputId = generateId('ts-select');
   private triggerEl?: HTMLElement;
+  private searchInputEl?: HTMLInputElement;
 
   /** The current value. */
   @Prop({ mutable: true, reflect: true }) value = '';
@@ -64,6 +65,12 @@ export class TsSelect {
   /** Allow multiple selections. */
   @Prop({ reflect: true }) multiple = false;
 
+  /** Enable search/filter input in the dropdown. */
+  @Prop({ reflect: true }) searchable = false;
+
+  /** Show a clear button when a value is selected. */
+  @Prop({ reflect: true }) clearable = false;
+
   /** Whether the dropdown is open. */
   @State() isOpen = false;
 
@@ -72,6 +79,9 @@ export class TsSelect {
 
   /** Parsed options from slotted <option> elements. */
   @State() options: SelectOption[] = [];
+
+  /** Current search query for filtering options. */
+  @State() searchQuery = '';
 
   /** Emitted when the value changes. */
   @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<TsSelectChangeEventDetail>;
@@ -125,25 +135,74 @@ export class TsSelect {
     return option.value === this.value;
   }
 
+  private getFilteredOptions(): SelectOption[] {
+    if (!this.searchable || !this.searchQuery) return this.options;
+    const query = this.searchQuery.toLowerCase();
+    return this.options.filter((o) => o.label.toLowerCase().includes(query));
+  }
+
   private open(): void {
     if (this.disabled) return;
     this.isOpen = true;
+    this.searchQuery = '';
+    const filtered = this.getFilteredOptions();
     if (this.multiple) {
       const selectedValues = this.getSelectedValues();
       this.focusedIndex = selectedValues.length > 0
-        ? this.options.findIndex((o) => o.value === selectedValues[0])
+        ? filtered.findIndex((o) => o.value === selectedValues[0])
         : 0;
     } else {
-      this.focusedIndex = this.options.findIndex((o) => o.value === this.value);
+      this.focusedIndex = filtered.findIndex((o) => o.value === this.value);
     }
     if (this.focusedIndex < 0) this.focusedIndex = 0;
+
+    if (this.searchable) {
+      requestAnimationFrame(() => this.searchInputEl?.focus());
+    }
   }
 
   private close(): void {
     this.isOpen = false;
     this.focusedIndex = -1;
+    this.searchQuery = '';
     this.triggerEl?.focus();
   }
+
+  private handleClear = (event: MouseEvent): void => {
+    event.stopPropagation();
+    this.value = '';
+    this.tsChange.emit({ value: this.value });
+  };
+
+  private handleSearchInput = (event: Event): void => {
+    this.searchQuery = (event.target as HTMLInputElement).value;
+    this.focusedIndex = 0;
+  };
+
+  private handleSearchKeydown = (event: KeyboardEvent): void => {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        this.moveFocusFiltered(1);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        this.moveFocusFiltered(-1);
+        break;
+      case 'Enter': {
+        event.preventDefault();
+        const filtered = this.getFilteredOptions();
+        if (this.focusedIndex >= 0 && filtered[this.focusedIndex] && !filtered[this.focusedIndex].disabled) {
+          this.selectOption(filtered[this.focusedIndex]);
+        }
+        break;
+      }
+      case 'Escape':
+        event.preventDefault();
+        this.close();
+        break;
+    }
+  };
 
   private selectOption(option: SelectOption): void {
     if (option.disabled) return;
@@ -175,6 +234,7 @@ export class TsSelect {
   };
 
   private handleTriggerKeydown = (event: KeyboardEvent): void => {
+    const filtered = this.getFilteredOptions();
     switch (event.key) {
       case 'Enter':
       case ' ':
@@ -183,8 +243,8 @@ export class TsSelect {
         if (!this.isOpen) {
           this.open();
         } else if (event.key === 'Enter' || event.key === ' ') {
-          if (this.focusedIndex >= 0 && this.options[this.focusedIndex]) {
-            this.selectOption(this.options[this.focusedIndex]);
+          if (this.focusedIndex >= 0 && filtered[this.focusedIndex]) {
+            this.selectOption(filtered[this.focusedIndex]);
           }
         }
         break;
@@ -204,21 +264,22 @@ export class TsSelect {
   };
 
   private handleDropdownKeydown = (event: KeyboardEvent): void => {
-    const enabledOptions = this.options.filter((o) => !o.disabled);
+    const filtered = this.getFilteredOptions();
+    const enabledOptions = filtered.filter((o) => !o.disabled);
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
-        this.moveFocus(1);
+        this.moveFocusFiltered(1);
         break;
       case 'ArrowUp':
         event.preventDefault();
-        this.moveFocus(-1);
+        this.moveFocusFiltered(-1);
         break;
       case 'Enter':
       case ' ':
         event.preventDefault();
-        if (this.focusedIndex >= 0 && this.options[this.focusedIndex] && !this.options[this.focusedIndex].disabled) {
-          this.selectOption(this.options[this.focusedIndex]);
+        if (this.focusedIndex >= 0 && filtered[this.focusedIndex] && !filtered[this.focusedIndex].disabled) {
+          this.selectOption(filtered[this.focusedIndex]);
         }
         break;
       case 'Escape':
@@ -227,21 +288,22 @@ export class TsSelect {
         break;
       case 'Home':
         event.preventDefault();
-        this.focusedIndex = enabledOptions.length > 0 ? this.options.indexOf(enabledOptions[0]) : 0;
+        this.focusedIndex = enabledOptions.length > 0 ? filtered.indexOf(enabledOptions[0]) : 0;
         break;
       case 'End':
         event.preventDefault();
-        this.focusedIndex = enabledOptions.length > 0 ? this.options.indexOf(enabledOptions[enabledOptions.length - 1]) : this.options.length - 1;
+        this.focusedIndex = enabledOptions.length > 0 ? filtered.indexOf(enabledOptions[enabledOptions.length - 1]) : filtered.length - 1;
         break;
     }
   };
 
-  private moveFocus(direction: number): void {
+  private moveFocusFiltered(direction: number): void {
+    const filtered = this.getFilteredOptions();
     let next = this.focusedIndex + direction;
-    while (next >= 0 && next < this.options.length && this.options[next].disabled) {
+    while (next >= 0 && next < filtered.length && filtered[next].disabled) {
       next += direction;
     }
-    if (next >= 0 && next < this.options.length) {
+    if (next >= 0 && next < filtered.length) {
       this.focusedIndex = next;
     }
   }
@@ -276,6 +338,15 @@ export class TsSelect {
     const errorId = `${this.inputId}-error`;
     const listboxId = `${this.inputId}-listbox`;
     const displayText = this.getDisplayText();
+    const filteredOptions = this.getFilteredOptions();
+    const focusedOptionId = this.isOpen && this.focusedIndex >= 0 && filteredOptions[this.focusedIndex]
+      ? `${this.inputId}-option-${this.focusedIndex}`
+      : undefined;
+
+    const describedByParts: string[] = [];
+    if (hasError) describedByParts.push(errorId);
+    if (!hasError && this.helpText) describedByParts.push(helpId);
+    const ariaDescribedBy = describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
     return (
       <Host
@@ -310,6 +381,8 @@ export class TsSelect {
             aria-haspopup="listbox"
             aria-controls={listboxId}
             aria-labelledby={this.label ? labelId : undefined}
+            aria-activedescendant={focusedOptionId}
+            aria-describedby={ariaDescribedBy}
             aria-invalid={this.error ? 'true' : undefined}
             aria-required={this.required ? 'true' : undefined}
             disabled={this.disabled}
@@ -321,6 +394,19 @@ export class TsSelect {
             <span class={{ 'select__display': true, 'select__display--placeholder': !displayText }}>
               {displayText || this.placeholder || '\u00A0'}
             </span>
+            {this.clearable && this.value && (
+              <button
+                class="select__clear"
+                type="button"
+                aria-label="Clear selection"
+                onClick={this.handleClear}
+                tabindex={-1}
+              >
+                <svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                  <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </button>
+            )}
             <svg class="select__chevron" viewBox="0 0 16 16" fill="none" aria-hidden="true">
               <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
@@ -336,35 +422,54 @@ export class TsSelect {
               aria-multiselectable={this.multiple ? 'true' : undefined}
               onKeyDown={this.handleDropdownKeydown}
             >
-              {this.options.map((option, index) => {
-                const selected = this.isOptionSelected(option);
-                return (
-                  <div
-                    class={{
-                      'select__option': true,
-                      'select__option--selected': selected,
-                      'select__option--focused': index === this.focusedIndex,
-                      'select__option--disabled': option.disabled,
-                    }}
-                    part="option"
-                    role="option"
-                    aria-selected={selected ? 'true' : 'false'}
-                    aria-disabled={option.disabled ? 'true' : undefined}
-                    onClick={() => this.selectOption(option)}
-                  >
-                    {this.multiple && (
-                      <span class="select__check" aria-hidden="true">
-                        {selected ? (
-                          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
-                          </svg>
-                        ) : null}
-                      </span>
-                    )}
-                    {option.label}
-                  </div>
-                );
-              })}
+              {this.searchable && (
+                <input
+                  ref={(el) => (this.searchInputEl = el)}
+                  class="select__search"
+                  type="text"
+                  placeholder="Search..."
+                  value={this.searchQuery}
+                  onInput={this.handleSearchInput}
+                  onKeyDown={this.handleSearchKeydown}
+                  aria-label="Search options"
+                  autocomplete="off"
+                />
+              )}
+              {filteredOptions.length > 0
+                ? filteredOptions.map((option, index) => {
+                    const selected = this.isOptionSelected(option);
+                    return (
+                      <div
+                        class={{
+                          'select__option': true,
+                          'select__option--selected': selected,
+                          'select__option--focused': index === this.focusedIndex,
+                          'select__option--disabled': option.disabled,
+                        }}
+                        part="option"
+                        role="option"
+                        id={`${this.inputId}-option-${index}`}
+                        aria-selected={selected ? 'true' : 'false'}
+                        aria-disabled={option.disabled ? 'true' : undefined}
+                        onClick={() => this.selectOption(option)}
+                      >
+                        {this.multiple && (
+                          <span class="select__check" aria-hidden="true">
+                            {selected ? (
+                              <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <polyline points="3.5 8.5 6.5 11.5 12.5 4.5" />
+                              </svg>
+                            ) : null}
+                          </span>
+                        )}
+                        {option.label}
+                      </div>
+                    );
+                  })
+                : (
+                  <div class="select__no-results">No results found</div>
+                )
+              }
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Add `searchable` prop with search input for filtering options in the dropdown
- Add `clearable` prop with clear button to reset selection
- Add `aria-activedescendant` for proper screen reader option tracking
- Add `aria-describedby` linking to error/help text

## Test plan
- [x] 21 unit tests pass
- [x] Build passes

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)