### PR TITLE
feat: add sidebar component

### DIFF
--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -1,0 +1,126 @@
+/* ==========================================================================
+   ts-sidebar — Shadow DOM Scoped Styles
+
+   Component tokens (Tier 3):
+     --ts-sidebar-bg            Background color
+     --ts-sidebar-border        Border color
+     --ts-sidebar-toggle-size   Toggle button size
+   ========================================================================== */
+
+:host {
+  display: flex;
+  flex-direction: column;
+  border-inline-end: 1px solid var(--ts-color-border-default);
+  background: var(--ts-color-bg-surface);
+  font-family: var(--ts-font-family-base);
+  block-size: 100%;
+  transition: width var(--ts-transition-normal);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+/* ---- Container ---- */
+.sidebar__container {
+  display: flex;
+  flex-direction: column;
+  block-size: 100%;
+  min-block-size: 0;
+}
+
+/* ---- Header (sticky top) ---- */
+.sidebar__header {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 1;
+  flex-shrink: 0;
+  padding: var(--ts-spacing-4);
+}
+
+.sidebar__header:empty {
+  display: none;
+}
+
+/* ---- Scrollable content ---- */
+.sidebar__content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: var(--ts-spacing-2) var(--ts-spacing-4);
+  min-block-size: 0;
+}
+
+/* ---- Footer (sticky bottom) ---- */
+.sidebar__footer {
+  position: sticky;
+  inset-block-end: 0;
+  z-index: 1;
+  flex-shrink: 0;
+  padding: var(--ts-spacing-4);
+}
+
+.sidebar__footer:empty {
+  display: none;
+}
+
+/* ---- Toggle button ---- */
+.sidebar__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 32px;
+  block-size: 32px;
+  padding: 0;
+  margin-block-start: var(--ts-spacing-2);
+  border: 1px solid var(--ts-color-border-default);
+  border-radius: var(--ts-shape-interactive);
+  background: var(--ts-color-bg-surface);
+  color: var(--ts-color-text-secondary);
+  cursor: pointer;
+  transition:
+    background-color var(--ts-transition-fast),
+    color var(--ts-transition-fast);
+}
+
+.sidebar__toggle:hover {
+  background-color: var(--ts-color-bg-subtle);
+  color: var(--ts-color-text-primary);
+}
+
+.sidebar__toggle:focus-visible {
+  box-shadow: var(--ts-focus-ring);
+  outline: none;
+}
+
+.sidebar__toggle-icon {
+  inline-size: 16px;
+  block-size: 16px;
+  transition: transform var(--ts-transition-fast);
+}
+
+.sidebar__toggle-icon--collapsed {
+  transform: rotate(180deg);
+}
+
+/* ---- Collapsed state ---- */
+:host([collapsed]) .sidebar__header,
+:host([collapsed]) .sidebar__content {
+  padding-inline: var(--ts-spacing-2);
+}
+
+:host([collapsed]) .sidebar__footer {
+  padding-inline: var(--ts-spacing-2);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* ---- Reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+  :host {
+    transition-duration: 0.01ms !important;
+  }
+
+  .sidebar__toggle-icon {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/src/components/sidebar/sidebar.e2e.ts
+++ b/src/components/sidebar/sidebar.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-sidebar e2e', () => {
+  it('renders on the page', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-sidebar>Navigation</ts-sidebar>');
+
+    const element = await page.find('ts-sidebar');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/sidebar/sidebar.spec.ts
+++ b/src/components/sidebar/sidebar.spec.ts
@@ -1,0 +1,101 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsSidebar } from './sidebar';
+
+describe('ts-sidebar', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar>Nav content</ts-sidebar>',
+    });
+
+    const container = page.root?.shadowRoot?.querySelector('.sidebar__container');
+    expect(container).not.toBeNull();
+    expect(page.root?.getAttribute('collapsed')).toBeNull();
+  });
+
+  it('applies collapsed class when collapsed prop is set', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar collapsed>Nav content</ts-sidebar>',
+    });
+
+    expect(page.root).toHaveClass('ts-sidebar--collapsed');
+    expect(page.root).toHaveAttribute('collapsed');
+  });
+
+  it('renders toggle button when collapsible', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar collapsible>Nav content</ts-sidebar>',
+    });
+
+    const toggle = page.root?.shadowRoot?.querySelector('.sidebar__toggle');
+    expect(toggle).not.toBeNull();
+    expect(toggle?.getAttribute('aria-label')).toBe('Collapse sidebar');
+  });
+
+  it('does not render toggle button when not collapsible', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar>Nav content</ts-sidebar>',
+    });
+
+    const toggle = page.root?.shadowRoot?.querySelector('.sidebar__toggle');
+    expect(toggle).toBeNull();
+  });
+
+  it('applies custom width via style', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar width="300px">Nav content</ts-sidebar>',
+    });
+
+    expect(page.root?.style.width).toBe('300px');
+  });
+
+  it('sets width to 64px when collapsed', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar collapsed>Nav content</ts-sidebar>',
+    });
+
+    expect(page.root?.style.width).toBe('64px');
+  });
+
+  it('emits tsToggle when collapsed changes', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: '<ts-sidebar collapsible>Nav content</ts-sidebar>',
+    });
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsToggle', spy);
+
+    const toggle = page.root?.shadowRoot?.querySelector('.sidebar__toggle') as HTMLButtonElement;
+    toggle?.click();
+    await page.waitForChanges();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toEqual({ collapsed: true });
+  });
+
+  it('renders header, default, and footer slots', async () => {
+    const page = await newSpecPage({
+      components: [TsSidebar],
+      html: `
+        <ts-sidebar>
+          <div slot="header">Header</div>
+          <nav>Navigation</nav>
+          <div slot="footer">Footer</div>
+        </ts-sidebar>
+      `,
+    });
+
+    const header = page.root?.shadowRoot?.querySelector('.sidebar__header');
+    const content = page.root?.shadowRoot?.querySelector('.sidebar__content');
+    const footer = page.root?.shadowRoot?.querySelector('.sidebar__footer');
+    expect(header).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(footer).not.toBeNull();
+  });
+});

--- a/src/components/sidebar/sidebar.stories.ts
+++ b/src/components/sidebar/sidebar.stories.ts
@@ -1,0 +1,156 @@
+// Hand-written stories for ts-sidebar
+
+export default {
+  title: 'Components/Sidebar',
+  tags: ['autodocs'],
+  argTypes: {
+    collapsed: { control: 'boolean', description: 'Whether the sidebar is collapsed.' },
+    width: { control: 'text', description: 'The expanded width of the sidebar.' },
+    collapsible: { control: 'boolean', description: 'Whether the sidebar can be collapsed via a toggle button.' },
+  },
+};
+
+const Template = (args: Record<string, unknown>): string => {
+  const attrs: string[] = [];
+  if (args.collapsed) attrs.push('collapsed');
+  if (args.collapsible) attrs.push('collapsible');
+  if (args.width !== undefined && args.width !== null && args.width !== '') attrs.push(`width="${args.width}"`);
+  return `
+    <div style="height: 400px; display: flex; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-interactive);">
+      <ts-sidebar ${attrs.join(' ')}>
+        <div slot="header" style="font-weight: 600; font-size: 1.1em;">My App</div>
+        <ts-nav>
+          <ts-nav-item active>
+            <ts-icon name="home" slot="prefix"></ts-icon>
+            Dashboard
+          </ts-nav-item>
+          <ts-nav-item>
+            <ts-icon name="users" slot="prefix"></ts-icon>
+            Team
+          </ts-nav-item>
+          <ts-nav-item>
+            <ts-icon name="settings" slot="prefix"></ts-icon>
+            Settings
+          </ts-nav-item>
+        </ts-nav>
+        <div slot="footer" style="font-size: 0.85em; color: var(--ts-color-text-secondary);">v1.0.0</div>
+      </ts-sidebar>
+      <div style="flex: 1; padding: var(--ts-spacing-6);">
+        <h2 style="margin: 0;">Main Content</h2>
+        <p>This area represents the main content beside the sidebar.</p>
+      </div>
+    </div>
+  `;
+};
+
+export const Default = Object.assign(Template.bind({}) as typeof Template & { args: Record<string, unknown> }, {
+  args: {
+    collapsed: false,
+    width: '260px',
+    collapsible: false,
+  },
+});
+
+export const Collapsible = (): string => `
+  <div style="height: 400px; display: flex; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-interactive);">
+    <ts-sidebar collapsible>
+      <div slot="header" style="font-weight: 600; font-size: 1.1em;">My App</div>
+      <ts-nav>
+        <ts-nav-item active>
+          <ts-icon name="home" slot="prefix"></ts-icon>
+          Dashboard
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="file-text" slot="prefix"></ts-icon>
+          Documents
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="bar-chart" slot="prefix"></ts-icon>
+          Analytics
+        </ts-nav-item>
+      </ts-nav>
+      <div slot="footer" style="font-size: 0.85em; color: var(--ts-color-text-secondary);">v1.0.0</div>
+    </ts-sidebar>
+    <div style="flex: 1; padding: var(--ts-spacing-6);">
+      <h2 style="margin: 0;">Main Content</h2>
+      <p>Click the toggle button in the sidebar footer to collapse and expand.</p>
+    </div>
+  </div>
+`;
+
+export const Collapsed = (): string => `
+  <div style="height: 400px; display: flex; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-interactive);">
+    <ts-sidebar collapsed collapsible>
+      <div slot="header" style="font-weight: 600;">
+        <ts-icon name="layout-grid"></ts-icon>
+      </div>
+      <ts-nav>
+        <ts-nav-item active>
+          <ts-icon name="home" slot="prefix"></ts-icon>
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="users" slot="prefix"></ts-icon>
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="settings" slot="prefix"></ts-icon>
+        </ts-nav-item>
+      </ts-nav>
+    </ts-sidebar>
+    <div style="flex: 1; padding: var(--ts-spacing-6);">
+      <h2 style="margin: 0;">Collapsed Sidebar</h2>
+      <p>The sidebar starts in a collapsed state showing only icons.</p>
+    </div>
+  </div>
+`;
+
+export const WithNav = (): string => `
+  <div style="height: 500px; display: flex; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-interactive);">
+    <ts-sidebar collapsible width="280px">
+      <div slot="header" style="font-weight: 600; font-size: 1.1em; display: flex; align-items: center; gap: var(--ts-spacing-2);">
+        <ts-icon name="box"></ts-icon>
+        <span>Acme Inc</span>
+      </div>
+      <ts-nav>
+        <ts-nav-item active>
+          <ts-icon name="home" slot="prefix"></ts-icon>
+          Dashboard
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="inbox" slot="prefix"></ts-icon>
+          Inbox
+          <ts-chip slot="suffix" size="sm" variant="primary">12</ts-chip>
+        </ts-nav-item>
+        <ts-nav-divider></ts-nav-divider>
+        <ts-nav-item>
+          <ts-icon name="users" slot="prefix"></ts-icon>
+          Team Members
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="folder" slot="prefix"></ts-icon>
+          Projects
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="calendar" slot="prefix"></ts-icon>
+          Schedule
+        </ts-nav-item>
+        <ts-nav-divider></ts-nav-divider>
+        <ts-nav-item>
+          <ts-icon name="settings" slot="prefix"></ts-icon>
+          Settings
+        </ts-nav-item>
+        <ts-nav-item>
+          <ts-icon name="help-circle" slot="prefix"></ts-icon>
+          Help & Support
+        </ts-nav-item>
+      </ts-nav>
+      <div slot="footer" style="display: flex; align-items: center; gap: var(--ts-spacing-2);">
+        <ts-avatar size="sm" initials="JD"></ts-avatar>
+        <span style="font-size: 0.85em;">Jane Doe</span>
+      </div>
+    </ts-sidebar>
+    <div style="flex: 1; padding: var(--ts-spacing-6);">
+      <h2 style="margin: 0;">Welcome back, Jane</h2>
+      <p>Here's what's happening with your projects today.</p>
+    </div>
+  </div>
+`;

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -1,0 +1,94 @@
+import { Component, Prop, Event, h, Host, Watch } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
+
+/**
+ * @slot header - Content displayed at the top of the sidebar (sticky).
+ * @slot - Default slot for navigation content (scrollable).
+ * @slot footer - Content displayed at the bottom of the sidebar (sticky).
+ *
+ * @part container - The main sidebar container.
+ * @part header - The header slot wrapper.
+ * @part content - The scrollable content area.
+ * @part footer - The footer slot wrapper.
+ * @part toggle - The collapse toggle button.
+ */
+@Component({
+  tag: 'ts-sidebar',
+  styleUrl: 'sidebar.css',
+  shadow: true,
+})
+export class TsSidebar {
+  /** Whether the sidebar is collapsed. */
+  @Prop({ reflect: true, mutable: true }) collapsed = false;
+
+  /** The expanded width of the sidebar. */
+  @Prop() width = '260px';
+
+  /** Whether the sidebar can be collapsed via a toggle button. */
+  @Prop({ reflect: true }) collapsible = false;
+
+  /** Emitted when the sidebar collapsed state changes. */
+  @Event({ eventName: 'tsToggle' }) tsToggle!: EventEmitter<{ collapsed: boolean }>;
+
+  @Watch('collapsed')
+  handleCollapsedChange(): void {
+    this.tsToggle.emit({ collapsed: this.collapsed });
+  }
+
+  private handleToggleClick = (): void => {
+    this.collapsed = !this.collapsed;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    const sidebarWidth = this.collapsed ? '64px' : this.width;
+
+    return (
+      <Host
+        style={{ width: sidebarWidth }}
+        class={{
+          'ts-sidebar': true,
+          'ts-sidebar--collapsed': this.collapsed,
+        }}
+      >
+        <div class="sidebar__container" part="container">
+          <div class="sidebar__header" part="header">
+            <slot name="header" />
+          </div>
+
+          <div class="sidebar__content" part="content">
+            <slot />
+          </div>
+
+          <div class="sidebar__footer" part="footer">
+            <slot name="footer" />
+            {this.collapsible && (
+              <button
+                class="sidebar__toggle"
+                part="toggle"
+                type="button"
+                aria-label={this.collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+                onClick={this.handleToggleClick}
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class={{
+                    'sidebar__toggle-icon': true,
+                    'sidebar__toggle-icon--collapsed': this.collapsed,
+                  }}
+                >
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,3 +78,4 @@ export { TsNumberInput } from './components/number-input/number-input';
 export { TsTagInput } from './components/tag-input/tag-input';
 export { TsScrollArea } from './components/scroll-area/scroll-area';
 export { TsPageHeader } from './components/page-header/page-header';
+export { TsSidebar } from './components/sidebar/sidebar';


### PR DESCRIPTION
## Summary
New `ts-sidebar` component with collapsible layout, header/nav/footer slots, and toggle between expanded/icon-only modes.

## Test plan
- [x] 8 unit tests pass
- [x] Build passes

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)