### PR TITLE
feat: add app layout component

### DIFF
--- a/src/components/app-layout/app-layout.css
+++ b/src/components/app-layout/app-layout.css
@@ -1,0 +1,37 @@
+:host {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: 1fr;
+  min-block-size: 100vh;
+  font-family: var(--ts-font-family-base);
+}
+
+:host(.ts-app-layout--sidebar-end) {
+  grid-template-columns: 1fr auto;
+}
+
+:host(.ts-app-layout--sidebar-end) .app-layout__sidebar {
+  order: 1;
+}
+
+.app-layout__sidebar {
+  grid-row: 1 / -1;
+}
+
+.app-layout__main {
+  display: flex;
+  flex-direction: column;
+  min-inline-size: 0;
+}
+
+.app-layout__header {
+  position: sticky;
+  inset-block-start: 0;
+  z-index: 10;
+  background: var(--ts-color-bg-surface);
+  border-block-end: 1px solid var(--ts-color-border-default);
+}
+
+.app-layout__content {
+  flex: 1;
+}

--- a/src/components/app-layout/app-layout.e2e.ts
+++ b/src/components/app-layout/app-layout.e2e.ts
@@ -1,0 +1,25 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-app-layout e2e', () => {
+  it('renders on the page', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<ts-app-layout>Main content</ts-app-layout>');
+
+    const element = await page.find('ts-app-layout');
+    expect(element).toHaveClass('hydrated');
+  });
+
+  it('renders slotted content', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-app-layout>
+        <nav slot="sidebar">Sidebar nav</nav>
+        <div slot="header">App Header</div>
+        <p>Page content</p>
+      </ts-app-layout>
+    `);
+
+    const element = await page.find('ts-app-layout');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/app-layout/app-layout.spec.ts
+++ b/src/components/app-layout/app-layout.spec.ts
@@ -1,0 +1,72 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsAppLayout } from './app-layout';
+
+describe('ts-app-layout', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [TsAppLayout],
+      html: '<ts-app-layout></ts-app-layout>',
+    });
+
+    expect(page.root).not.toBeNull();
+    const sidebar = page.root?.shadowRoot?.querySelector('.app-layout__sidebar');
+    const header = page.root?.shadowRoot?.querySelector('.app-layout__header');
+    const content = page.root?.shadowRoot?.querySelector('.app-layout__content');
+    expect(sidebar).not.toBeNull();
+    expect(header).not.toBeNull();
+    expect(content).not.toBeNull();
+  });
+
+  it('defaults sidebarPlacement to start', async () => {
+    const page = await newSpecPage({
+      components: [TsAppLayout],
+      html: '<ts-app-layout></ts-app-layout>',
+    });
+
+    expect(page.root?.getAttribute('sidebar-placement')).toBe('start');
+  });
+
+  it('applies sidebar-end class when sidebarPlacement is end', async () => {
+    const page = await newSpecPage({
+      components: [TsAppLayout],
+      html: '<ts-app-layout sidebar-placement="end"></ts-app-layout>',
+    });
+
+    expect(page.root?.getAttribute('sidebar-placement')).toBe('end');
+    expect(page.root?.classList.contains('ts-app-layout--sidebar-end')).toBe(true);
+  });
+
+  it('has named slots for sidebar and header', async () => {
+    const page = await newSpecPage({
+      components: [TsAppLayout],
+      html: `
+        <ts-app-layout>
+          <div slot="sidebar">Sidebar</div>
+          <div slot="header">Header</div>
+          <p>Main content</p>
+        </ts-app-layout>
+      `,
+    });
+
+    const sidebarSlot = page.root?.shadowRoot?.querySelector('slot[name="sidebar"]');
+    const headerSlot = page.root?.shadowRoot?.querySelector('slot[name="header"]');
+    const defaultSlot = page.root?.shadowRoot?.querySelector('slot:not([name])');
+    expect(sidebarSlot).not.toBeNull();
+    expect(headerSlot).not.toBeNull();
+    expect(defaultSlot).not.toBeNull();
+  });
+
+  it('exposes CSS parts', async () => {
+    const page = await newSpecPage({
+      components: [TsAppLayout],
+      html: '<ts-app-layout></ts-app-layout>',
+    });
+
+    const sidebar = page.root?.shadowRoot?.querySelector('[part="sidebar"]');
+    const header = page.root?.shadowRoot?.querySelector('[part="header"]');
+    const content = page.root?.shadowRoot?.querySelector('[part="content"]');
+    expect(sidebar).not.toBeNull();
+    expect(header).not.toBeNull();
+    expect(content).not.toBeNull();
+  });
+});

--- a/src/components/app-layout/app-layout.stories.ts
+++ b/src/components/app-layout/app-layout.stories.ts
@@ -1,0 +1,113 @@
+// Hand-written stories for ts-app-layout
+
+export default {
+  title: 'Components/App Layout',
+  tags: ['autodocs'],
+  argTypes: {
+    sidebarPlacement: {
+      control: 'select',
+      options: ['start', 'end'],
+      description: 'Controls which side the sidebar appears on.',
+    },
+  },
+};
+
+const sidebarContent = `
+  <nav slot="sidebar" style="width: 240px; background: var(--ts-color-bg-surface); border-inline-end: 1px solid var(--ts-color-border-default); padding: var(--ts-spacing-4);">
+    <div style="font-weight: 600; font-size: 1.125rem; margin-block-end: var(--ts-spacing-4);">Acme App</div>
+    <ts-nav>
+      <ts-nav-item active>
+        <ts-icon slot="prefix" name="home" size="sm"></ts-icon>
+        Dashboard
+      </ts-nav-item>
+      <ts-nav-item>
+        <ts-icon slot="prefix" name="users" size="sm"></ts-icon>
+        Team Members
+      </ts-nav-item>
+      <ts-nav-item>
+        <ts-icon slot="prefix" name="folder" size="sm"></ts-icon>
+        Projects
+      </ts-nav-item>
+      <ts-nav-divider></ts-nav-divider>
+      <ts-nav-item>
+        <ts-icon slot="prefix" name="settings" size="sm"></ts-icon>
+        Settings
+      </ts-nav-item>
+    </ts-nav>
+  </nav>
+`;
+
+const headerContent = `
+  <div slot="header" style="display: flex; align-items: center; justify-content: space-between; padding: var(--ts-spacing-3) var(--ts-spacing-4);">
+    <h2 style="margin: 0; font-size: 1rem; font-weight: 600;">Dashboard</h2>
+    <ts-row gap="2">
+      <ts-button size="sm" appearance="ghost" variant="neutral">
+        <ts-icon slot="prefix" name="bell" size="sm"></ts-icon>
+        Notifications
+      </ts-button>
+      <ts-avatar size="sm" initials="JD"></ts-avatar>
+    </ts-row>
+  </div>
+`;
+
+const mainContent = `
+  <div style="padding: var(--ts-spacing-6);">
+    <ts-stack gap="4">
+      <h1 style="margin: 0;">Welcome back, Jane</h1>
+      <ts-row gap="4">
+        <ts-card bordered style="flex: 1;">
+          <span slot="header"><strong>Total Users</strong></span>
+          <p style="margin: 0; font-size: 2rem; font-weight: 700;">1,284</p>
+        </ts-card>
+        <ts-card bordered style="flex: 1;">
+          <span slot="header"><strong>Active Projects</strong></span>
+          <p style="margin: 0; font-size: 2rem; font-weight: 700;">12</p>
+        </ts-card>
+        <ts-card bordered style="flex: 1;">
+          <span slot="header"><strong>Open Tasks</strong></span>
+          <p style="margin: 0; font-size: 2rem; font-weight: 700;">47</p>
+        </ts-card>
+      </ts-row>
+    </ts-stack>
+  </div>
+`;
+
+const Template = (args: Record<string, unknown>): string => {
+  const attrs: string[] = [];
+  if (args.sidebarPlacement && args.sidebarPlacement !== 'start') {
+    attrs.push(`sidebar-placement="${args.sidebarPlacement}"`);
+  }
+  return `
+    <ts-app-layout ${attrs.join(' ')} style="min-height: 500px; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-container);">
+      ${sidebarContent}
+      ${headerContent}
+      ${mainContent}
+    </ts-app-layout>
+  `;
+};
+
+export const Default = Object.assign(Template.bind({}) as typeof Template & { args: Record<string, unknown> }, {
+  args: {
+    sidebarPlacement: 'start',
+  },
+});
+
+export const SidebarEnd = (): string => `
+  <ts-app-layout sidebar-placement="end" style="min-height: 500px; border: 1px solid var(--ts-color-border-default); border-radius: var(--ts-shape-container);">
+    ${mainContent}
+    <nav slot="sidebar" style="width: 260px; background: var(--ts-color-bg-surface); border-inline-start: 1px solid var(--ts-color-border-default); padding: var(--ts-spacing-4);">
+      <div style="font-weight: 600; margin-block-end: var(--ts-spacing-4);">Details Panel</div>
+      <ts-stack gap="3">
+        <ts-card bordered>
+          <span slot="header"><strong>Task Info</strong></span>
+          <p style="margin: 0; color: var(--ts-color-text-secondary);">Review the quarterly metrics report and prepare summary slides.</p>
+        </ts-card>
+        <ts-button variant="primary" block>
+          <ts-icon slot="prefix" name="check" size="sm"></ts-icon>
+          Mark Complete
+        </ts-button>
+      </ts-stack>
+    </nav>
+    ${headerContent}
+  </ts-app-layout>
+`;

--- a/src/components/app-layout/app-layout.tsx
+++ b/src/components/app-layout/app-layout.tsx
@@ -1,0 +1,41 @@
+import { Component, Prop, h, Host } from '@stencil/core';
+
+/**
+ * A layout shell that provides a sidebar, header, and main content area using CSS Grid.
+ *
+ * @slot sidebar - Content for the sidebar panel (e.g., navigation).
+ * @slot header - Content for the top header bar.
+ * @slot - Default slot for the main content area.
+ *
+ * @part sidebar - The sidebar container.
+ * @part header - The header container.
+ * @part content - The main content container.
+ */
+@Component({
+  tag: 'ts-app-layout',
+  styleUrl: 'app-layout.css',
+  shadow: true,
+})
+export class TsAppLayout {
+  /** Controls which side the sidebar appears on. */
+  @Prop({ reflect: true }) sidebarPlacement: 'start' | 'end' = 'start';
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    return (
+      <Host class={{ 'ts-app-layout': true, [`ts-app-layout--sidebar-${this.sidebarPlacement}`]: true }}>
+        <aside class="app-layout__sidebar" part="sidebar">
+          <slot name="sidebar" />
+        </aside>
+        <div class="app-layout__main">
+          <header class="app-layout__header" part="header">
+            <slot name="header" />
+          </header>
+          <main class="app-layout__content" part="content">
+            <slot />
+          </main>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,3 +79,4 @@ export { TsTagInput } from './components/tag-input/tag-input';
 export { TsScrollArea } from './components/scroll-area/scroll-area';
 export { TsPageHeader } from './components/page-header/page-header';
 export { TsSidebar } from './components/sidebar/sidebar';
+export { TsAppLayout } from './components/app-layout/app-layout';


### PR DESCRIPTION
## Summary
New `ts-app-layout` CSS Grid shell with sidebar, header, and main content slots. Supports start/end sidebar placement.

## Test plan
- [x] 5 unit tests pass
- [x] Build passes

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)