### PR TITLE
feat: add combobox component

### DIFF
--- a/src/components/combobox/combobox.css
+++ b/src/components/combobox/combobox.css
@@ -1,0 +1,229 @@
+/* ==========================================================================
+   ts-combobox — Shadow DOM Scoped Styles
+
+   Component tokens (Tier 3):
+     --ts-combobox-bg              Combobox background
+     --ts-combobox-border-color    Default border color
+     --ts-combobox-radius          Border radius
+     --ts-combobox-focus-ring      Focus ring box-shadow
+   ========================================================================== */
+
+:host {
+  display: block;
+  font-family: var(--ts-font-family-base);
+
+  --ts-combobox-bg: var(--ts-color-neutral-50);
+  --ts-combobox-border-color: var(--ts-color-border-default);
+  --ts-combobox-radius: var(--ts-radius-md);
+  --ts-combobox-focus-ring: var(--ts-focus-ring);
+}
+
+/* ---- Label ---- */
+.combobox__label {
+  display: block;
+  margin-block-end: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-sm);
+  font-weight: var(--ts-font-weight-medium);
+  color: var(--ts-color-text-secondary);
+  line-height: var(--ts-line-height-normal);
+}
+
+.combobox__required {
+  color: var(--ts-color-danger-500);
+}
+
+/* ---- Container ---- */
+.combobox__container {
+  position: relative;
+}
+
+/* ---- Input Wrapper ---- */
+.combobox__input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: var(--ts-spacing-2);
+  width: 100%;
+  border: 1px solid var(--ts-combobox-border-color);
+  border-radius: var(--ts-combobox-radius);
+  background-color: var(--ts-combobox-bg);
+  transition:
+    border-color var(--ts-transition-fast),
+    box-shadow var(--ts-transition-fast);
+}
+
+.combobox__input-wrapper:focus-within {
+  border-color: var(--ts-color-primary-500);
+  box-shadow: var(--ts-combobox-focus-ring);
+}
+
+.combobox__input-wrapper--error {
+  border-color: var(--ts-color-danger-500);
+}
+
+.combobox__input-wrapper--error:focus-within {
+  box-shadow: 0 0 0 3px var(--ts-color-focus-ring-danger);
+}
+
+.combobox__input-wrapper--disabled {
+  background-color: var(--ts-color-bg-disabled);
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.combobox__input-wrapper--open {
+  border-color: var(--ts-color-primary-500);
+  box-shadow: var(--ts-combobox-focus-ring);
+}
+
+/* ---- Input ---- */
+.combobox__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: inherit;
+  color: var(--ts-color-text-primary);
+  outline: none;
+  min-width: 0;
+}
+
+.combobox__input::placeholder {
+  color: var(--ts-color-text-tertiary);
+}
+
+.combobox__input:disabled {
+  cursor: not-allowed;
+}
+
+/* ---- Chevron Button ---- */
+.combobox__chevron-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.combobox__chevron-btn:disabled {
+  cursor: not-allowed;
+}
+
+/* ---- Chevron ---- */
+.combobox__chevron {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  transition: transform var(--ts-transition-fast);
+  color: var(--ts-color-text-tertiary);
+}
+
+:host(.ts-combobox--open) .combobox__chevron {
+  transform: rotate(180deg);
+}
+
+/* ---- Dropdown ---- */
+.combobox__dropdown {
+  position: absolute;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  top: calc(100% + var(--ts-spacing-1));
+  z-index: 1000;
+  background-color: var(--ts-color-bg-elevated);
+  border: 1px solid var(--ts-color-border-default);
+  border-radius: var(--ts-radius-md);
+  box-shadow: var(--ts-shadow-lg);
+  max-height: 15rem;
+  overflow-y: auto;
+  padding-block: var(--ts-spacing-1);
+}
+
+/* ---- Option ---- */
+.combobox__option {
+  display: flex;
+  align-items: center;
+  padding: var(--ts-spacing-2) var(--ts-spacing-3);
+  cursor: pointer;
+  transition:
+    background-color var(--ts-transition-fast),
+    color var(--ts-transition-fast);
+  color: var(--ts-color-text-primary);
+  font-size: inherit;
+}
+
+.combobox__option:hover:not(.combobox__option--disabled) {
+  background-color: var(--ts-color-interactive-primary-subtle);
+}
+
+.combobox__option--focused {
+  background-color: var(--ts-color-bg-subtle);
+}
+
+.combobox__option--selected {
+  color: var(--ts-color-interactive-primary);
+  font-weight: var(--ts-font-weight-medium);
+}
+
+.combobox__option--disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ---- Sizes ---- */
+:host([size="sm"]) .combobox__input-wrapper {
+  padding: var(--ts-spacing-1) var(--ts-spacing-2);
+  font-size: var(--ts-font-size-sm);
+  border-radius: var(--ts-radius-sm);
+}
+
+:host([size="md"]) .combobox__input-wrapper {
+  padding: var(--ts-spacing-2) var(--ts-spacing-3);
+  font-size: var(--ts-font-size-md);
+}
+
+:host([size="lg"]) .combobox__input-wrapper {
+  padding: var(--ts-spacing-3) var(--ts-spacing-4);
+  font-size: var(--ts-font-size-lg);
+}
+
+:host([size="xl"]) .combobox__input-wrapper {
+  padding: var(--ts-spacing-4) var(--ts-spacing-5);
+  font-size: var(--ts-font-size-xl);
+  border-radius: var(--ts-radius-lg);
+}
+
+/* ---- Hidden slot ---- */
+.combobox__hidden-slot {
+  display: none;
+}
+
+/* ---- Help & Error Text ---- */
+.combobox__help,
+.combobox__error {
+  margin-block-start: var(--ts-spacing-1);
+  font-size: var(--ts-font-size-xs);
+  line-height: var(--ts-line-height-normal);
+}
+
+.combobox__help {
+  color: var(--ts-color-text-tertiary);
+}
+
+.combobox__error {
+  color: var(--ts-color-danger-600);
+  font-weight: var(--ts-font-weight-medium);
+}
+
+@media (forced-colors: active) {
+  .combobox__input-wrapper {
+    border: 1px solid ButtonText;
+  }
+  .combobox__input-wrapper--disabled {
+    border-color: GrayText;
+  }
+  .combobox__input-wrapper:focus-within {
+    outline: 2px solid Highlight;
+  }
+}

--- a/src/components/combobox/combobox.e2e.ts
+++ b/src/components/combobox/combobox.e2e.ts
@@ -1,0 +1,17 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('ts-combobox e2e', () => {
+  it('renders on the page', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-combobox>
+        <option value="us">United States</option>
+        <option value="uk">United Kingdom</option>
+        <option value="ca">Canada</option>
+      </ts-combobox>
+    `);
+
+    const element = await page.find('ts-combobox');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/src/components/combobox/combobox.spec.ts
+++ b/src/components/combobox/combobox.spec.ts
@@ -1,0 +1,187 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TsCombobox } from './combobox';
+
+describe('ts-combobox', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-combobox>`,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector('.combobox__input');
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute('role')).toBe('combobox');
+    expect(input?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('renders label text', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox label="Search country">
+        <option value="us">United States</option>
+      </ts-combobox>`,
+    });
+
+    const label = page.root?.shadowRoot?.querySelector('.combobox__label');
+    expect(label?.textContent).toContain('Search country');
+  });
+
+  it('renders required indicator', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox label="Country" required>
+        <option value="us">United States</option>
+      </ts-combobox>`,
+    });
+
+    const required = page.root?.shadowRoot?.querySelector('.combobox__required');
+    expect(required).not.toBeNull();
+  });
+
+  it('filters options based on input value', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox>
+        <option value="us">United States</option>
+        <option value="uk">United Kingdom</option>
+        <option value="ca">Canada</option>
+      </ts-combobox>`,
+    });
+
+    const combobox = page.rootInstance as TsCombobox;
+    (combobox as unknown as { inputValue: string }).inputValue = 'United';
+    (combobox as unknown as { isOpen: boolean }).isOpen = true;
+    await page.waitForChanges();
+
+    const options = page.root?.shadowRoot?.querySelectorAll('.combobox__option');
+    expect(options?.length).toBe(2);
+  });
+
+  it('selects an option and updates value', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox>
+        <option value="us">United States</option>
+        <option value="uk">United Kingdom</option>
+      </ts-combobox>`,
+    });
+
+    const combobox = page.rootInstance as TsCombobox;
+    // Directly invoke selectOption via the internal method
+    (combobox as unknown as { selectOption: (o: { value: string; label: string; disabled: boolean }) => void }).selectOption({ value: 'us', label: 'United States', disabled: false });
+    await page.waitForChanges();
+
+    expect(page.root?.value).toBe('us');
+  });
+
+  it('shows placeholder text', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox placeholder="Type to search">
+        <option value="a">A</option>
+      </ts-combobox>`,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector('.combobox__input');
+    expect(input?.getAttribute('placeholder')).toBe('Type to search');
+  });
+
+  it('has disabled state with correct attributes', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox disabled>
+        <option value="a">A</option>
+      </ts-combobox>`,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector('.combobox__input');
+    expect(input?.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('renders error message', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox error="Please select a country">
+        <option value="us">United States</option>
+      </ts-combobox>`,
+    });
+
+    const errorEl = page.root?.shadowRoot?.querySelector('.combobox__error');
+    expect(errorEl?.textContent).toContain('Please select a country');
+  });
+
+  it('renders help text when no error', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox help-text="Start typing to search">
+        <option value="a">A</option>
+      </ts-combobox>`,
+    });
+
+    const helpEl = page.root?.shadowRoot?.querySelector('.combobox__help');
+    expect(helpEl?.textContent).toContain('Start typing to search');
+  });
+
+  it('has correct aria attributes on input', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox label="Country" required>
+        <option value="us">United States</option>
+      </ts-combobox>`,
+    });
+
+    const input = page.root?.shadowRoot?.querySelector('.combobox__input');
+    expect(input?.getAttribute('role')).toBe('combobox');
+    expect(input?.getAttribute('aria-haspopup')).toBe('listbox');
+    expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+    expect(input?.getAttribute('aria-required')).toBe('true');
+  });
+
+  it('renders listbox when open', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox>
+        <option value="a">Option A</option>
+      </ts-combobox>`,
+    });
+
+    const combobox = page.rootInstance as TsCombobox;
+    (combobox as unknown as { isOpen: boolean }).isOpen = true;
+    await page.waitForChanges();
+
+    const listbox = page.root?.shadowRoot?.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+  });
+
+  it('reflects size prop to host attribute', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox size="lg">
+        <option value="a">A</option>
+      </ts-combobox>`,
+    });
+
+    expect(page.root?.getAttribute('size')).toBe('lg');
+  });
+
+  it('marks focused option with aria-activedescendant', async () => {
+    const page = await newSpecPage({
+      components: [TsCombobox],
+      html: `<ts-combobox>
+        <option value="a">Option A</option>
+        <option value="b">Option B</option>
+      </ts-combobox>`,
+    });
+
+    const combobox = page.rootInstance as TsCombobox;
+    (combobox as unknown as { isOpen: boolean }).isOpen = true;
+    (combobox as unknown as { focusedIndex: number }).focusedIndex = 1;
+    await page.waitForChanges();
+
+    const input = page.root?.shadowRoot?.querySelector('.combobox__input');
+    expect(input?.getAttribute('aria-activedescendant')).toBeTruthy();
+  });
+});

--- a/src/components/combobox/combobox.stories.ts
+++ b/src/components/combobox/combobox.stories.ts
@@ -1,0 +1,138 @@
+// Hand-written stories for ts-combobox
+
+export default {
+  title: 'Components/Combobox',
+  tags: ['autodocs'],
+  argTypes: {
+    value: { control: 'text', description: 'The current selected value.' },
+    label: { control: 'text', description: 'Label text displayed above the combobox.' },
+    placeholder: { control: 'text', description: 'Placeholder text for the input.' },
+    disabled: { control: 'boolean', description: 'Renders the combobox as disabled.' },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'The combobox size.',
+    },
+    error: { control: 'text', description: 'Error message displayed below the combobox.' },
+    helpText: { control: 'text', description: 'Help text displayed below the combobox.' },
+    required: { control: 'boolean', description: 'Makes the combobox required.' },
+  },
+};
+
+const Template = (args: Record<string, unknown>): string => {
+  const attrs: string[] = [];
+  if (args.value !== undefined && args.value !== null && args.value !== '') attrs.push(`value="${args.value}"`);
+  if (args.label !== undefined && args.label !== null) attrs.push(`label="${args.label}"`);
+  if (args.placeholder !== undefined && args.placeholder !== null) attrs.push(`placeholder="${args.placeholder}"`);
+  if (args.disabled) attrs.push('disabled');
+  if (args.size !== undefined && args.size !== null) attrs.push(`size="${args.size}"`);
+  if (args.error !== undefined && args.error !== null && args.error !== '') attrs.push(`error="${args.error}"`);
+  if (args.helpText !== undefined && args.helpText !== null) attrs.push(`help-text="${args.helpText}"`);
+  if (args.required) attrs.push('required');
+  return `
+    <ts-combobox ${attrs.join(' ')}>
+      <option value="us">United States</option>
+      <option value="uk">United Kingdom</option>
+      <option value="ca">Canada</option>
+      <option value="au">Australia</option>
+      <option value="de">Germany</option>
+      <option value="fr">France</option>
+      <option value="jp">Japan</option>
+      <option value="br">Brazil</option>
+    </ts-combobox>
+  `;
+};
+
+export const Default = Object.assign(Template.bind({}) as typeof Template & { args: Record<string, unknown> }, {
+  args: {
+    value: '',
+    label: 'Country',
+    placeholder: 'Search for a country',
+    disabled: false,
+    size: 'md',
+    error: '',
+    helpText: 'Type to filter the list of countries.',
+    required: false,
+  },
+});
+
+export const WithFiltering = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 24px; max-width: 320px;">
+    <ts-combobox label="Programming Language" placeholder="Type to search..." help-text="Start typing to filter options.">
+      <option value="js">JavaScript</option>
+      <option value="ts">TypeScript</option>
+      <option value="py">Python</option>
+      <option value="rs">Rust</option>
+      <option value="go">Go</option>
+      <option value="java">Java</option>
+      <option value="rb">Ruby</option>
+      <option value="cpp">C++</option>
+    </ts-combobox>
+    <ts-combobox label="City" placeholder="Search cities..." value="nyc">
+      <option value="nyc">New York</option>
+      <option value="ldn">London</option>
+      <option value="tky">Tokyo</option>
+      <option value="par">Paris</option>
+      <option value="syd">Sydney</option>
+      <option value="ber">Berlin</option>
+    </ts-combobox>
+  </div>
+`;
+
+export const ErrorState = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 24px; max-width: 320px;">
+    <ts-combobox label="Department" placeholder="Select a department" error="Please select a valid department." required>
+      <option value="eng">Engineering</option>
+      <option value="des">Design</option>
+      <option value="mkt">Marketing</option>
+      <option value="sales">Sales</option>
+    </ts-combobox>
+    <ts-combobox label="Manager" placeholder="Search for a manager" error="This field is required." required>
+      <option value="jd">Jane Doe</option>
+      <option value="js">John Smith</option>
+      <option value="ak">Alice Kim</option>
+    </ts-combobox>
+  </div>
+`;
+
+export const Sizes = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+    <ts-combobox size="sm" label="Small" placeholder="Search...">
+      <option value="opt1">First option</option>
+      <option value="opt2">Second option</option>
+      <option value="opt3">Third option</option>
+    </ts-combobox>
+    <ts-combobox size="md" label="Medium" placeholder="Search...">
+      <option value="opt1">First option</option>
+      <option value="opt2">Second option</option>
+      <option value="opt3">Third option</option>
+    </ts-combobox>
+    <ts-combobox size="lg" label="Large" placeholder="Search...">
+      <option value="opt1">First option</option>
+      <option value="opt2">Second option</option>
+      <option value="opt3">Third option</option>
+    </ts-combobox>
+  </div>
+`;
+
+export const States = (): string => `
+  <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+    <ts-combobox label="Default" placeholder="Type to search">
+      <option value="a">Option A</option>
+      <option value="b">Option B</option>
+    </ts-combobox>
+    <ts-combobox label="With Value" value="react" placeholder="Search framework">
+      <option value="react">React</option>
+      <option value="vue">Vue</option>
+      <option value="angular">Angular</option>
+      <option value="svelte">Svelte</option>
+    </ts-combobox>
+    <ts-combobox label="Disabled" disabled placeholder="Cannot search">
+      <option value="a">Option A</option>
+    </ts-combobox>
+    <ts-combobox label="Required" required placeholder="Must select" help-text="This field is required.">
+      <option value="a">Option A</option>
+      <option value="b">Option B</option>
+    </ts-combobox>
+  </div>
+`;

--- a/src/components/combobox/combobox.tsx
+++ b/src/components/combobox/combobox.tsx
@@ -1,0 +1,360 @@
+import { Component, Prop, State, Event, Watch, h, Host, Element, Listen } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
+import type { TsSize } from '../../types';
+import { generateId } from '../../utils/aria';
+
+interface ComboboxOption {
+  value: string;
+  label: string;
+  disabled: boolean;
+}
+
+/**
+ * @slot - Default slot for `<option>` elements.
+ *
+ * @part base - The outer wrapper.
+ * @part label - The label element.
+ * @part input-wrapper - The input wrapper containing the text input and chevron.
+ * @part input - The text input element.
+ * @part dropdown - The dropdown panel.
+ * @part option - An option in the dropdown list.
+ * @part help-text - The help text wrapper.
+ * @part error-text - The error message wrapper.
+ */
+@Component({
+  tag: 'ts-combobox',
+  styleUrl: 'combobox.css',
+  shadow: true,
+})
+export class TsCombobox {
+  @Element() hostEl!: HTMLElement;
+
+  private inputId = generateId('ts-combobox');
+  private inputEl?: HTMLInputElement;
+
+  /** The current selected value. */
+  @Prop({ mutable: true, reflect: true }) value = '';
+
+  /** Label text displayed above the combobox. */
+  @Prop() label?: string;
+
+  /** Placeholder text for the input. */
+  @Prop() placeholder?: string;
+
+  /** Renders the combobox as disabled. */
+  @Prop({ reflect: true }) disabled = false;
+
+  /** The combobox size. */
+  @Prop({ reflect: true }) size: TsSize = 'md';
+
+  /** Error message displayed below the combobox. */
+  @Prop() error?: string;
+
+  /** Help text displayed below the combobox. */
+  @Prop() helpText?: string;
+
+  /** Makes the combobox required. */
+  @Prop({ reflect: true }) required = false;
+
+  /** The current text in the input. */
+  @State() inputValue = '';
+
+  /** Whether the dropdown is open. */
+  @State() isOpen = false;
+
+  /** The index of the currently focused option in the filtered list. */
+  @State() focusedIndex = -1;
+
+  /** Parsed options from slotted <option> elements. */
+  @State() options: ComboboxOption[] = [];
+
+  /** Emitted when a value is selected. */
+  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string }>;
+
+  /** Emitted when the input text changes. */
+  @Event({ eventName: 'tsInput' }) tsInput!: EventEmitter<{ inputValue: string }>;
+
+  @Watch('value')
+  handleValueChange(): void {
+    const match = this.options.find((o) => o.value === this.value);
+    if (match) {
+      this.inputValue = match.label;
+    }
+  }
+
+  @Listen('click', { target: 'document' })
+  handleDocumentClick(event: MouseEvent): void {
+    if (this.isOpen && !this.hostEl.contains(event.target as Node)) {
+      this.close();
+    }
+  }
+
+  componentWillLoad(): void {
+    this.parseOptions();
+    if (this.value) {
+      const match = this.options.find((o) => o.value === this.value);
+      if (match) {
+        this.inputValue = match.label;
+      }
+    }
+  }
+
+  componentDidLoad(): void {
+    const slot = this.hostEl.shadowRoot?.querySelector('.combobox__hidden-slot slot');
+    slot?.addEventListener('slotchange', () => this.parseOptions());
+  }
+
+  private parseOptions(): void {
+    const slottedOptions = this.hostEl.querySelectorAll('option');
+    this.options = Array.from(slottedOptions).map((opt) => ({
+      value: opt.value,
+      label: opt.textContent?.trim() ?? opt.value,
+      disabled: opt.disabled,
+    }));
+  }
+
+  private getFilteredOptions(): ComboboxOption[] {
+    if (!this.inputValue) return this.options;
+    const query = this.inputValue.toLowerCase();
+    return this.options.filter((o) => o.label.toLowerCase().includes(query));
+  }
+
+  private open(): void {
+    if (this.disabled) return;
+    this.isOpen = true;
+    this.focusedIndex = -1;
+  }
+
+  private close(): void {
+    this.isOpen = false;
+    this.focusedIndex = -1;
+  }
+
+  private selectOption(option: ComboboxOption): void {
+    if (option.disabled) return;
+    this.value = option.value;
+    this.inputValue = option.label;
+    this.tsChange.emit({ value: this.value });
+    this.close();
+    this.inputEl?.focus();
+  }
+
+  private handleInput = (event: Event): void => {
+    const target = event.target as HTMLInputElement;
+    this.inputValue = target.value;
+    this.tsInput.emit({ inputValue: this.inputValue });
+    if (!this.isOpen) {
+      this.open();
+    }
+    this.focusedIndex = -1;
+  };
+
+  private handleInputClick = (): void => {
+    if (!this.isOpen) {
+      this.open();
+    }
+  };
+
+  private handleKeydown = (event: KeyboardEvent): void => {
+    const filtered = this.getFilteredOptions();
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (!this.isOpen) {
+          this.open();
+        } else {
+          this.moveFocus(1, filtered);
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (!this.isOpen) {
+          this.open();
+        } else {
+          this.moveFocus(-1, filtered);
+        }
+        break;
+      case 'Enter':
+        event.preventDefault();
+        if (this.isOpen && this.focusedIndex >= 0 && filtered[this.focusedIndex]) {
+          this.selectOption(filtered[this.focusedIndex]);
+        }
+        break;
+      case 'Escape':
+        if (this.isOpen) {
+          event.preventDefault();
+          this.close();
+        }
+        break;
+      case 'Home':
+        if (this.isOpen) {
+          event.preventDefault();
+          const firstEnabled = filtered.findIndex((o) => !o.disabled);
+          this.focusedIndex = firstEnabled >= 0 ? firstEnabled : 0;
+        }
+        break;
+      case 'End':
+        if (this.isOpen) {
+          event.preventDefault();
+          let lastEnabled = -1;
+          for (let i = filtered.length - 1; i >= 0; i--) {
+            if (!filtered[i].disabled) {
+              lastEnabled = i;
+              break;
+            }
+          }
+          this.focusedIndex = lastEnabled >= 0 ? lastEnabled : filtered.length - 1;
+        }
+        break;
+    }
+  };
+
+  private moveFocus(direction: number, filtered: ComboboxOption[]): void {
+    let next = this.focusedIndex + direction;
+    while (next >= 0 && next < filtered.length && filtered[next].disabled) {
+      next += direction;
+    }
+    if (next >= 0 && next < filtered.length) {
+      this.focusedIndex = next;
+    }
+  }
+
+  private handleChevronClick = (): void => {
+    if (this.disabled) return;
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+      this.inputEl?.focus();
+    }
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  render() {
+    const hasError = !!this.error;
+    const labelId = `${this.inputId}-label`;
+    const helpId = `${this.inputId}-help`;
+    const errorId = `${this.inputId}-error`;
+    const listboxId = `${this.inputId}-listbox`;
+    const filtered = this.getFilteredOptions();
+    const activeDescendant =
+      this.focusedIndex >= 0 ? `${this.inputId}-option-${this.focusedIndex}` : undefined;
+
+    return (
+      <Host
+        class={{
+          'ts-combobox': true,
+          [`ts-combobox--${this.size}`]: true,
+          'ts-combobox--open': this.isOpen,
+          'ts-combobox--disabled': this.disabled,
+          'ts-combobox--error': hasError,
+        }}
+      >
+        {this.label && (
+          <label class="combobox__label" part="label" id={labelId}>
+            {this.label}
+            {this.required && <span class="combobox__required" aria-hidden="true"> *</span>}
+          </label>
+        )}
+
+        <div class="combobox__container">
+          <div
+            class={{
+              'combobox__input-wrapper': true,
+              'combobox__input-wrapper--open': this.isOpen,
+              'combobox__input-wrapper--error': hasError,
+              'combobox__input-wrapper--disabled': this.disabled,
+            }}
+            part="input-wrapper"
+          >
+            <input
+              ref={(el) => (this.inputEl = el as HTMLInputElement | undefined)}
+              class="combobox__input"
+              part="input"
+              type="text"
+              role="combobox"
+              value={this.inputValue}
+              placeholder={this.placeholder}
+              disabled={this.disabled}
+              aria-expanded={this.isOpen ? 'true' : 'false'}
+              aria-haspopup="listbox"
+              aria-controls={listboxId}
+              aria-activedescendant={activeDescendant}
+              aria-labelledby={this.label ? labelId : undefined}
+              aria-invalid={hasError ? 'true' : undefined}
+              aria-required={this.required ? 'true' : undefined}
+              aria-describedby={hasError ? errorId : this.helpText ? helpId : undefined}
+              aria-autocomplete="list"
+              autocomplete="off"
+              onInput={this.handleInput}
+              onClick={this.handleInputClick}
+              onKeyDown={this.handleKeydown}
+            />
+            <button
+              class="combobox__chevron-btn"
+              type="button"
+              tabindex={-1}
+              aria-hidden="true"
+              disabled={this.disabled}
+              onClick={this.handleChevronClick}
+            >
+              <svg class="combobox__chevron" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path d="M4 6L8 10L12 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </button>
+          </div>
+
+          {this.isOpen && filtered.length > 0 && (
+            <div
+              class="combobox__dropdown"
+              part="dropdown"
+              role="listbox"
+              id={listboxId}
+              aria-labelledby={this.label ? labelId : undefined}
+            >
+              {filtered.map((option, index) => {
+                const isSelected = option.value === this.value;
+                return (
+                  <div
+                    class={{
+                      'combobox__option': true,
+                      'combobox__option--selected': isSelected,
+                      'combobox__option--focused': index === this.focusedIndex,
+                      'combobox__option--disabled': option.disabled,
+                    }}
+                    part="option"
+                    role="option"
+                    id={`${this.inputId}-option-${index}`}
+                    aria-selected={isSelected ? 'true' : 'false'}
+                    aria-disabled={option.disabled ? 'true' : undefined}
+                    onClick={() => this.selectOption(option)}
+                  >
+                    {option.label}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Hidden slot to capture <option> elements */}
+        <div class="combobox__hidden-slot">
+          <slot />
+        </div>
+
+        {hasError && (
+          <div class="combobox__error" part="error-text" id={errorId} role="alert">
+            {this.error}
+          </div>
+        )}
+
+        {!hasError && this.helpText && (
+          <div class="combobox__help" part="help-text" id={helpId}>
+            {this.helpText}
+          </div>
+        )}
+      </Host>
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,3 +82,4 @@ export { TsSidebar } from './components/sidebar/sidebar';
 export { TsAppLayout } from './components/app-layout/app-layout';
 export { TsTimeline } from './components/timeline/timeline';
 export { TsTimelineItem } from './components/timeline/timeline-item';
+export { TsCombobox } from './components/combobox/combobox';


### PR DESCRIPTION
## Summary
New `ts-combobox` component — text input with filterable dropdown suggestions, keyboard navigation, and `aria-activedescendant`. Options parsed from slotted `<option>` elements.

## Test plan
- [x] 13 unit tests pass
- [x] Build passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)