### PR TITLE
feat(table): add column sorting and row selection

### DIFF
--- a/src/components/table/table.css
+++ b/src/components/table/table.css
@@ -110,3 +110,45 @@ ts-table.ts-table--sticky-header th {
   top: 0;
   z-index: 1;
 }
+
+/* ---- Sortable ---- */
+ts-table.ts-table--sortable th {
+  cursor: pointer;
+  user-select: none;
+  transition: background-color var(--ts-transition-fast);
+}
+
+ts-table.ts-table--sortable th:hover {
+  background-color: var(--ts-table-row-hover-bg);
+}
+
+.table__sort-indicator {
+  display: inline;
+  font-size: var(--ts-font-size-xs);
+  color: var(--ts-color-text-tertiary);
+  margin-inline-start: var(--ts-spacing-1);
+}
+
+th[aria-sort="ascending"] .table__sort-indicator,
+th[aria-sort="descending"] .table__sort-indicator {
+  color: var(--ts-color-text-primary);
+}
+
+/* ---- Selectable / Checkbox column ---- */
+ts-table .table__checkbox {
+  width: 2.5rem;
+  padding: var(--ts-table-cell-padding);
+  text-align: center;
+  vertical-align: middle;
+}
+
+ts-table .table__checkbox input[type="checkbox"] {
+  cursor: pointer;
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--ts-color-primary);
+}
+
+ts-table.ts-table--selectable tbody tr[data-value] {
+  transition: background-color var(--ts-transition-fast);
+}

--- a/src/components/table/table.e2e.ts
+++ b/src/components/table/table.e2e.ts
@@ -57,4 +57,65 @@ describe('ts-table e2e', () => {
     expect(element).toHaveAttribute('hoverable');
     expect(element).toHaveAttribute('compact');
   });
+
+  it('sets aria-sort on sortable header click', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-table sortable>
+        <table>
+          <thead><tr><th data-column="name">Name</th><th data-column="email">Email</th></tr></thead>
+          <tbody><tr><td>Alice</td><td>alice@example.com</td></tr></tbody>
+        </table>
+      </ts-table>
+    `);
+
+    const th = await page.find('th[data-column="name"]');
+    await th.click();
+    await page.waitForChanges();
+
+    const ariaSort = await th.getAttribute('aria-sort');
+    expect(ariaSort).toBe('ascending');
+  });
+
+  it('emits tsSort event on header click', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-table sortable>
+        <table>
+          <thead><tr><th data-column="name">Name</th></tr></thead>
+          <tbody><tr><td>Alice</td></tr></tbody>
+        </table>
+      </ts-table>
+    `);
+
+    const sortEvent = await page.spyOnEvent('tsSort');
+    const th = await page.find('th[data-column="name"]');
+    await th.click();
+    await page.waitForChanges();
+
+    expect(sortEvent).toHaveReceivedEventDetail({ column: 'name', direction: 'asc' });
+  });
+
+  it('renders checkboxes when selectable is enabled', async () => {
+    const page = await newE2EPage();
+    await page.setContent(`
+      <ts-table selectable>
+        <table>
+          <thead><tr><th>Name</th></tr></thead>
+          <tbody>
+            <tr data-value="alice"><td>Alice</td></tr>
+            <tr data-value="bob"><td>Bob</td></tr>
+          </tbody>
+        </table>
+      </ts-table>
+    `);
+
+    await page.waitForChanges();
+
+    const headerCheckbox = await page.find('thead th.table__checkbox input[type="checkbox"]');
+    expect(headerCheckbox).not.toBeNull();
+
+    const rowCheckboxes = await page.findAll('tbody td.table__checkbox input[type="checkbox"]');
+    expect(rowCheckboxes.length).toBe(2);
+  });
 });

--- a/src/components/table/table.spec.ts
+++ b/src/components/table/table.spec.ts
@@ -88,4 +88,133 @@ describe('ts-table', () => {
     expect(page.root?.classList.contains('ts-table--bordered')).toBe(true);
     expect(page.root?.classList.contains('ts-table--hoverable')).toBe(true);
   });
+
+  it('applies sortable class when sortable prop is set', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table sortable>
+          <table>
+            <thead><tr><th data-column="name">Name</th></tr></thead>
+            <tbody><tr><td>Alice</td></tr></tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    expect(page.root?.classList.contains('ts-table--sortable')).toBe(true);
+  });
+
+  it('sets aria-sort on header after sort column and direction are set', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table sortable sort-column="name" sort-direction="asc">
+          <table>
+            <thead><tr><th data-column="name">Name</th><th data-column="email">Email</th></tr></thead>
+            <tbody><tr><td>Alice</td><td>alice@example.com</td></tr></tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const th = page.root?.querySelector('th[data-column="name"]');
+    expect(th?.getAttribute('aria-sort')).toBe('ascending');
+  });
+
+  it('emits tsSort event on header click', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table sortable>
+          <table>
+            <thead><tr><th data-column="name">Name</th></tr></thead>
+            <tbody><tr><td>Alice</td></tr></tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsSort', spy);
+
+    const th = page.root?.querySelector('th[data-column="name"]') as HTMLElement;
+    th?.click();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toEqual({ column: 'name', direction: 'asc' });
+  });
+
+  it('applies selectable class when selectable prop is set', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table selectable>
+          <table>
+            <thead><tr><th>Name</th></tr></thead>
+            <tbody>
+              <tr data-value="alice"><td>Alice</td></tr>
+            </tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    expect(page.root?.classList.contains('ts-table--selectable')).toBe(true);
+  });
+
+  it('adds checkboxes when selectable is enabled', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table selectable>
+          <table>
+            <thead><tr><th>Name</th></tr></thead>
+            <tbody>
+              <tr data-value="alice"><td>Alice</td></tr>
+              <tr data-value="bob"><td>Bob</td></tr>
+            </tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const headerCheckbox = page.root?.querySelector('thead th.table__checkbox input[type="checkbox"]');
+    expect(headerCheckbox).not.toBeNull();
+
+    const rowCheckboxes = page.root?.querySelectorAll('tbody td.table__checkbox input[type="checkbox"]');
+    expect(rowCheckboxes?.length).toBe(2);
+  });
+
+  it('emits tsSelectionChange when a row checkbox is clicked', async () => {
+    const page = await newSpecPage({
+      components: [TsTable],
+      html: `
+        <ts-table selectable>
+          <table>
+            <thead><tr><th>Name</th></tr></thead>
+            <tbody>
+              <tr data-value="alice"><td>Alice</td></tr>
+            </tbody>
+          </table>
+        </ts-table>
+      `,
+    });
+
+    await page.waitForChanges();
+
+    const spy = jest.fn();
+    page.root?.addEventListener('tsSelectionChange', spy);
+
+    const checkbox = page.root?.querySelector('tbody td.table__checkbox input[type="checkbox"]') as HTMLInputElement;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event('change'));
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].detail).toEqual({ selectedRows: ['alice'] });
+  });
 });

--- a/src/components/table/table.stories.ts
+++ b/src/components/table/table.stories.ts
@@ -9,6 +9,8 @@ export default {
     hoverable: { control: 'boolean', description: 'Highlights rows on hover.' },
     compact: { control: 'boolean', description: 'Reduces cell padding for denser display.' },
     stickyHeader: { control: 'boolean', description: 'Makes the table header stick to the top on scroll.' },
+    sortable: { control: 'boolean', description: 'Enables column sorting on header click.' },
+    selectable: { control: 'boolean', description: 'Enables row selection with checkboxes.' },
   },
 };
 
@@ -64,6 +66,8 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.hoverable) attrs.push('hoverable');
   if (args.compact) attrs.push('compact');
   if (args.stickyHeader) attrs.push('sticky-header');
+  if (args.sortable) attrs.push('sortable');
+  if (args.selectable) attrs.push('selectable');
   return `<ts-table ${attrs.join(' ')}>${sampleTable}</ts-table>`;
 };
 
@@ -149,4 +153,79 @@ export const CompactBordered = (): string => `
       </tbody>
     </table>
   </ts-table>
+`;
+
+export const Sortable = (): string => `
+  <ts-table sortable hoverable>
+    <table>
+      <thead>
+        <tr>
+          <th data-column="name">Name</th>
+          <th data-column="email">Email</th>
+          <th data-column="role">Role</th>
+          <th data-column="status">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr><td>James Kennedy</td><td>james@example.com</td><td>Admin</td><td>Active</td></tr>
+        <tr><td>Alice Smith</td><td>alice@example.com</td><td>Editor</td><td>Active</td></tr>
+        <tr><td>Robert Chen</td><td>robert@example.com</td><td>Viewer</td><td>Inactive</td></tr>
+        <tr><td>Maria Garcia</td><td>maria@example.com</td><td>Editor</td><td>Active</td></tr>
+        <tr><td>David Lee</td><td>david@example.com</td><td>Viewer</td><td>Pending</td></tr>
+      </tbody>
+    </table>
+  </ts-table>
+  <p style="margin-top: 12px; color: var(--ts-color-text-tertiary); font-size: var(--ts-font-size-sm);">
+    Click any column header to sort. Click again to reverse the direction.
+  </p>
+`;
+
+export const WithSelection = (): string => `
+  <ts-table selectable hoverable>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Role</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr data-value="james"><td>James Kennedy</td><td>james@example.com</td><td>Admin</td></tr>
+        <tr data-value="alice"><td>Alice Smith</td><td>alice@example.com</td><td>Editor</td></tr>
+        <tr data-value="robert"><td>Robert Chen</td><td>robert@example.com</td><td>Viewer</td></tr>
+        <tr data-value="maria"><td>Maria Garcia</td><td>maria@example.com</td><td>Editor</td></tr>
+        <tr data-value="david"><td>David Lee</td><td>david@example.com</td><td>Viewer</td></tr>
+      </tbody>
+    </table>
+  </ts-table>
+  <p style="margin-top: 12px; color: var(--ts-color-text-tertiary); font-size: var(--ts-font-size-sm);">
+    Use checkboxes to select individual rows or the header checkbox to select all.
+  </p>
+`;
+
+export const FullFeatured = (): string => `
+  <ts-table sortable selectable striped hoverable bordered>
+    <table>
+      <thead>
+        <tr>
+          <th data-column="id">Order ID</th>
+          <th data-column="customer">Customer</th>
+          <th data-column="product">Product</th>
+          <th data-column="total">Total</th>
+          <th data-column="status">Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr data-value="ord-001"><td>#ORD-001</td><td>James Kennedy</td><td>Widget Pro</td><td>$149.97</td><td>Shipped</td></tr>
+        <tr data-value="ord-002"><td>#ORD-002</td><td>Alice Smith</td><td>Gadget Plus</td><td>$79.99</td><td>Processing</td></tr>
+        <tr data-value="ord-003"><td>#ORD-003</td><td>Robert Chen</td><td>Tool Kit</td><td>$199.98</td><td>Delivered</td></tr>
+        <tr data-value="ord-004"><td>#ORD-004</td><td>Maria Garcia</td><td>Widget Pro</td><td>$249.95</td><td>Shipped</td></tr>
+        <tr data-value="ord-005"><td>#ORD-005</td><td>David Lee</td><td>Gadget Plus</td><td>$79.99</td><td>Cancelled</td></tr>
+      </tbody>
+    </table>
+  </ts-table>
+  <p style="margin-top: 12px; color: var(--ts-color-text-tertiary); font-size: var(--ts-font-size-sm);">
+    Sorting, row selection, stripes, hover, and borders combined.
+  </p>
 `;

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -1,4 +1,5 @@
-import { Component, Prop, h, Host, Element } from '@stencil/core';
+import { Component, Prop, Event, Watch, h, Host, Element } from '@stencil/core';
+import type { EventEmitter } from '@stencil/core';
 
 /**
  * A styled wrapper for native HTML tables. Consumers place standard
@@ -32,6 +33,257 @@ export class TsTable {
   /** Makes the table header stick to the top on scroll. */
   @Prop({ reflect: true }) stickyHeader = false;
 
+  /** Enables column sorting on header click. */
+  @Prop({ reflect: true }) sortable = false;
+
+  /** The column identifier currently sorted by (matches `data-column` on `<th>`). */
+  @Prop({ reflect: true, mutable: true }) sortColumn?: string;
+
+  /** The current sort direction. */
+  @Prop({ reflect: true, mutable: true }) sortDirection: 'asc' | 'desc' | 'none' = 'none';
+
+  /** Enables row selection with checkboxes. */
+  @Prop({ reflect: true }) selectable = false;
+
+  /** Array of selected row values (matches `data-value` on `<tr>`). */
+  @Prop({ mutable: true }) selectedRows: string[] = [];
+
+  /** Emitted when a column header is clicked for sorting. */
+  @Event({ eventName: 'tsSort' }) tsSort!: EventEmitter<{ column: string; direction: 'asc' | 'desc' }>;
+
+  /** Emitted when row selection changes. */
+  @Event({ eventName: 'tsSelectionChange' }) tsSelectionChange!: EventEmitter<{ selectedRows: string[] }>;
+
+  private headerClickHandlers = new Map<HTMLElement, EventListener>();
+  private checkboxHandlers = new Map<HTMLElement, EventListener>();
+
+  componentDidLoad(): void {
+    this.setupSortable();
+    this.setupSelectable();
+  }
+
+  componentDidUpdate(): void {
+    this.setupSortable();
+    this.setupSelectable();
+  }
+
+  @Watch('sortColumn')
+  @Watch('sortDirection')
+  onSortChange(): void {
+    this.updateSortIndicators();
+  }
+
+  @Watch('selectedRows')
+  onSelectedRowsChange(): void {
+    this.updateCheckboxStates();
+  }
+
+  disconnectedCallback(): void {
+    this.cleanupSortHandlers();
+    this.cleanupCheckboxHandlers();
+  }
+
+  private cleanupSortHandlers(): void {
+    this.headerClickHandlers.forEach((handler, el) => {
+      el.removeEventListener('click', handler);
+    });
+    this.headerClickHandlers.clear();
+  }
+
+  private cleanupCheckboxHandlers(): void {
+    this.checkboxHandlers.forEach((handler, el) => {
+      el.removeEventListener('change', handler);
+    });
+    this.checkboxHandlers.clear();
+  }
+
+  private setupSortable(): void {
+    if (!this.sortable) return;
+
+    const headers = Array.from(this.hostEl.querySelectorAll('th'));
+
+    // Clean up old handlers first
+    this.cleanupSortHandlers();
+
+    headers.forEach((th) => {
+      const column = th.getAttribute('data-column') || th.textContent?.trim() || '';
+      if (!column) return;
+
+      // Remove any existing sort indicators before re-adding
+      const existingIndicator = th.querySelector('.table__sort-indicator');
+      if (existingIndicator) existingIndicator.remove();
+
+      const handler = (): void => {
+        this.handleSortClick(column);
+      };
+
+      th.addEventListener('click', handler);
+      this.headerClickHandlers.set(th, handler);
+    });
+
+    this.updateSortIndicators();
+  }
+
+  private handleSortClick(column: string): void {
+    let newDirection: 'asc' | 'desc';
+
+    if (this.sortColumn === column) {
+      newDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      newDirection = 'asc';
+    }
+
+    this.sortColumn = column;
+    this.sortDirection = newDirection;
+
+    this.tsSort.emit({ column, direction: newDirection });
+    this.updateSortIndicators();
+  }
+
+  private updateSortIndicators(): void {
+    if (!this.sortable) return;
+
+    const headers = Array.from(this.hostEl.querySelectorAll('th'));
+
+    headers.forEach((th) => {
+      const column = th.getAttribute('data-column') || th.textContent?.trim() || '';
+
+      // Remove existing indicator
+      const existing = th.querySelector('.table__sort-indicator');
+      if (existing) existing.remove();
+
+      // Set aria-sort
+      if (column === this.sortColumn && this.sortDirection !== 'none') {
+        th.setAttribute('aria-sort', this.sortDirection === 'asc' ? 'ascending' : 'descending');
+
+        const indicator = document.createElement('span');
+        indicator.className = 'table__sort-indicator';
+        indicator.textContent = this.sortDirection === 'asc' ? ' \u25B2' : ' \u25BC';
+        th.appendChild(indicator);
+      } else {
+        th.removeAttribute('aria-sort');
+      }
+    });
+  }
+
+  private setupSelectable(): void {
+    if (!this.selectable) return;
+
+    // Clean up old handlers
+    this.cleanupCheckboxHandlers();
+
+    const thead = this.hostEl.querySelector('thead');
+    const tbody = this.hostEl.querySelector('tbody');
+
+    if (!thead || !tbody) return;
+
+    // Add header checkbox if not already present
+    const headerRow = thead.querySelector('tr');
+    if (headerRow) {
+      let headerCheckboxTh = headerRow.querySelector('th.table__checkbox');
+      if (!headerCheckboxTh) {
+        headerCheckboxTh = document.createElement('th');
+        headerCheckboxTh.className = 'table__checkbox';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.setAttribute('aria-label', 'Select all rows');
+        headerCheckboxTh.appendChild(checkbox);
+        headerRow.insertBefore(headerCheckboxTh, headerRow.firstChild);
+      }
+
+      const headerCheckbox = headerCheckboxTh.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      if (headerCheckbox) {
+        const handler = (): void => {
+          this.handleSelectAll(headerCheckbox.checked);
+        };
+        headerCheckbox.addEventListener('change', handler);
+        this.checkboxHandlers.set(headerCheckbox, handler);
+      }
+    }
+
+    // Add row checkboxes
+    const rows = Array.from(tbody.querySelectorAll('tr[data-value]'));
+    rows.forEach((tr) => {
+      const value = tr.getAttribute('data-value') || '';
+      let checkboxTd = tr.querySelector('td.table__checkbox');
+      if (!checkboxTd) {
+        checkboxTd = document.createElement('td');
+        checkboxTd.className = 'table__checkbox';
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.setAttribute('aria-label', `Select row ${value}`);
+        checkboxTd.appendChild(checkbox);
+        tr.insertBefore(checkboxTd, tr.firstChild);
+      }
+
+      const checkbox = checkboxTd.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      if (checkbox) {
+        const handler = (): void => {
+          this.handleRowSelect(value, checkbox.checked);
+        };
+        checkbox.addEventListener('change', handler);
+        this.checkboxHandlers.set(checkbox, handler);
+      }
+    });
+
+    this.updateCheckboxStates();
+  }
+
+  private handleSelectAll(checked: boolean): void {
+    const tbody = this.hostEl.querySelector('tbody');
+    if (!tbody) return;
+
+    const rows = Array.from(tbody.querySelectorAll('tr[data-value]'));
+    if (checked) {
+      this.selectedRows = rows.map((tr) => tr.getAttribute('data-value') || '');
+    } else {
+      this.selectedRows = [];
+    }
+
+    this.tsSelectionChange.emit({ selectedRows: [...this.selectedRows] });
+    this.updateCheckboxStates();
+  }
+
+  private handleRowSelect(value: string, checked: boolean): void {
+    if (checked) {
+      this.selectedRows = [...this.selectedRows, value];
+    } else {
+      this.selectedRows = this.selectedRows.filter((v) => v !== value);
+    }
+
+    this.tsSelectionChange.emit({ selectedRows: [...this.selectedRows] });
+    this.updateCheckboxStates();
+  }
+
+  private updateCheckboxStates(): void {
+    if (!this.selectable) return;
+
+    const tbody = this.hostEl.querySelector('tbody');
+    const thead = this.hostEl.querySelector('thead');
+    if (!tbody) return;
+
+    // Update row checkboxes
+    const rows = Array.from(tbody.querySelectorAll('tr[data-value]'));
+    rows.forEach((tr) => {
+      const value = tr.getAttribute('data-value') || '';
+      const checkbox = tr.querySelector('td.table__checkbox input[type="checkbox"]') as HTMLInputElement;
+      if (checkbox) {
+        checkbox.checked = this.selectedRows.includes(value);
+      }
+    });
+
+    // Update header checkbox
+    if (thead) {
+      const headerCheckbox = thead.querySelector('th.table__checkbox input[type="checkbox"]') as HTMLInputElement;
+      if (headerCheckbox) {
+        const allSelected = rows.length > 0 && rows.every((tr) => this.selectedRows.includes(tr.getAttribute('data-value') || ''));
+        const someSelected = rows.some((tr) => this.selectedRows.includes(tr.getAttribute('data-value') || ''));
+        headerCheckbox.checked = allSelected;
+        headerCheckbox.indeterminate = someSelected && !allSelected;
+      }
+    }
+  }
+
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   render() {
     return (
@@ -43,6 +295,8 @@ export class TsTable {
           'ts-table--hoverable': this.hoverable,
           'ts-table--compact': this.compact,
           'ts-table--sticky-header': this.stickyHeader,
+          'ts-table--sortable': this.sortable,
+          'ts-table--selectable': this.selectable,
         }}
       >
         <div class="table__wrapper" role="region" tabindex={0}>


### PR DESCRIPTION
## Summary
- Add `sortable` prop with click-to-sort headers, sort indicators, and `aria-sort`
- Add `selectable` prop with checkbox column, select-all header, and `tsSelectionChange` event

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)