### PR TITLE
feat(date-picker): add range selection, year navigation, and locale

### DIFF
--- a/src/components/date-picker/date-picker.css
+++ b/src/components/date-picker/date-picker.css
@@ -226,6 +226,37 @@
   box-shadow: var(--ts-date-picker-focus-ring);
 }
 
+/* ---- Range selection ---- */
+.date-picker__day--in-range {
+  background-color: var(--ts-color-interactive-primary-subtle, rgba(59, 130, 246, 0.12));
+  border-radius: 0;
+}
+
+.date-picker__day--range-start {
+  background-color: var(--ts-color-interactive-primary);
+  color: var(--ts-color-text-on-primary);
+  font-weight: var(--ts-font-weight-semi);
+  border-radius: var(--ts-radius-full) 0 0 var(--ts-radius-full);
+}
+
+.date-picker__day--range-end {
+  background-color: var(--ts-color-interactive-primary);
+  color: var(--ts-color-text-on-primary);
+  font-weight: var(--ts-font-weight-semi);
+  border-radius: 0 var(--ts-radius-full) var(--ts-radius-full) 0;
+}
+
+.date-picker__day--range-start.date-picker__day--range-end {
+  border-radius: var(--ts-radius-full);
+}
+
+/* ---- Nav group ---- */
+.date-picker__nav-group {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
 /* ---- Animation ---- */
 @keyframes ts-dp-fade-in {
   from { opacity: 0; transform: translateY(-4px); }

--- a/src/components/date-picker/date-picker.spec.ts
+++ b/src/components/date-picker/date-picker.spec.ts
@@ -92,4 +92,60 @@ describe('ts-date-picker', () => {
     const input = page.root?.shadowRoot?.querySelector('input');
     expect(input?.getAttribute('name')).toBe('dob');
   });
+
+  it('renders year navigation buttons in calendar header', async () => {
+    const page = await newSpecPage({
+      components: [TsDatePicker],
+      html: '<ts-date-picker></ts-date-picker>',
+    });
+
+    // Open calendar by setting internal state
+    const component = page.rootInstance as TsDatePicker;
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    const buttons = page.root?.shadowRoot?.querySelectorAll('.date-picker__nav-btn');
+    expect(buttons?.length).toBe(4);
+
+    const labels = Array.from(buttons || []).map((b) => b.getAttribute('aria-label'));
+    expect(labels).toContain('Previous year');
+    expect(labels).toContain('Next year');
+  });
+
+  it('shifts weekday headers when firstDayOfWeek is set', async () => {
+    const page = await newSpecPage({
+      components: [TsDatePicker],
+      html: '<ts-date-picker first-day-of-week="1"></ts-date-picker>',
+    });
+
+    // Open calendar by setting internal state
+    const component = page.rootInstance as TsDatePicker;
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    const weekdays = page.root?.shadowRoot?.querySelectorAll('.date-picker__weekday');
+    const headers = Array.from(weekdays || []).map((el) => el.textContent);
+    expect(headers[0]).toBe('Mo');
+    expect(headers[6]).toBe('Su');
+  });
+
+  it('highlights selected range in range mode', async () => {
+    const page = await newSpecPage({
+      components: [TsDatePicker],
+      html: '<ts-date-picker range value="2024-06-05" value-end="2024-06-10"></ts-date-picker>',
+    });
+
+    // Open calendar by setting internal state
+    const component = page.rootInstance as TsDatePicker;
+    component.isOpen = true;
+    await page.waitForChanges();
+
+    const rangeStart = page.root?.shadowRoot?.querySelector('.date-picker__day--range-start');
+    const rangeEnd = page.root?.shadowRoot?.querySelector('.date-picker__day--range-end');
+    const inRange = page.root?.shadowRoot?.querySelectorAll('.date-picker__day--in-range');
+
+    expect(rangeStart).not.toBeNull();
+    expect(rangeEnd).not.toBeNull();
+    expect(inRange?.length).toBeGreaterThan(0);
+  });
 });

--- a/src/components/date-picker/date-picker.stories.ts
+++ b/src/components/date-picker/date-picker.stories.ts
@@ -45,6 +45,22 @@ export default {
       control: 'text',
       description: 'Form field name.',
     },
+    locale: {
+      control: 'text',
+      description: 'Locale string for date formatting (BCP 47).',
+    },
+    firstDayOfWeek: {
+      control: { type: 'number', min: 0, max: 6 },
+      description: 'First day of the week (0 = Sunday, 6 = Saturday).',
+    },
+    range: {
+      control: 'boolean',
+      description: 'Enable date range selection mode.',
+    },
+    valueEnd: {
+      control: 'text',
+      description: 'End date for range selection in ISO format.',
+    },
   },
 };
 
@@ -60,6 +76,10 @@ const Template = (args: Record<string, unknown>): string => {
   if (args.errorMessage !== undefined && args.errorMessage !== '') attrs.push(`error-message="${args.errorMessage}"`);
   if (args.size !== undefined) attrs.push(`size="${args.size}"`);
   if (args.name !== undefined && args.name !== '') attrs.push(`name="${args.name}"`);
+  if (args.locale !== undefined && args.locale !== '') attrs.push(`locale="${args.locale}"`);
+  if (args.firstDayOfWeek !== undefined) attrs.push(`first-day-of-week="${args.firstDayOfWeek}"`);
+  if (args.range) attrs.push('range');
+  if (args.valueEnd !== undefined && args.valueEnd !== '') attrs.push(`value-end="${args.valueEnd}"`);
   return `<ts-date-picker ${attrs.join(' ')}></ts-date-picker>`;
 };
 
@@ -87,6 +107,51 @@ export const States = (): string => `
     <ts-date-picker label="With value" value="2026-03-15" placeholder="Select date"></ts-date-picker>
     <ts-date-picker label="Disabled" placeholder="Select date" disabled></ts-date-picker>
     <ts-date-picker label="Error state" placeholder="Select date" error error-message="Please select a valid date"></ts-date-picker>
+  </div>
+`;
+
+export const WithYearNav = (): string => `
+  <div style="display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+    <ts-date-picker
+      label="Event date"
+      placeholder="Pick a date"
+      value="2024-06-15"
+    ></ts-date-picker>
+  </div>
+  <p style="margin-top: 12px; font-size: 14px; color: #6b7280;">
+    Use the double chevron buttons (&laquo; &raquo;) to navigate between years.
+  </p>
+`;
+
+export const RangeSelection = (): string => `
+  <div style="display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+    <ts-date-picker
+      label="Booking dates"
+      placeholder="Select date range"
+      range
+      value="2026-03-10"
+      value-end="2026-03-18"
+    ></ts-date-picker>
+    <ts-date-picker
+      label="Select new range"
+      placeholder="Click two dates"
+      range
+    ></ts-date-picker>
+  </div>
+`;
+
+export const CustomLocale = (): string => `
+  <div style="display: flex; gap: 24px; flex-wrap: wrap; align-items: flex-start;">
+    <ts-date-picker
+      label="Week starts Monday"
+      placeholder="Select date"
+      first-day-of-week="1"
+    ></ts-date-picker>
+    <ts-date-picker
+      label="Week starts Saturday"
+      placeholder="Select date"
+      first-day-of-week="6"
+    ></ts-date-picker>
   </div>
 `;
 

--- a/src/components/date-picker/date-picker.tsx
+++ b/src/components/date-picker/date-picker.tsx
@@ -2,7 +2,7 @@ import { Component, Prop, State, Event, h, Host, Element, Watch } from '@stencil
 import type { EventEmitter } from '@stencil/core';
 import { generateId } from '../../utils/aria';
 
-const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const DEFAULT_WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 
 /**
  * @part trigger - The input trigger element.
@@ -54,8 +54,20 @@ export class TsDatePicker {
   /** Form field name. */
   @Prop() name?: string;
 
+  /** Locale string for date formatting (BCP 47). */
+  @Prop() locale = 'en-US';
+
+  /** First day of the week (0 = Sunday, 1 = Monday, ... 6 = Saturday). */
+  @Prop() firstDayOfWeek = 0;
+
+  /** Enable date range selection mode. */
+  @Prop({ reflect: true }) range = false;
+
+  /** The end date of the selected range in ISO format (YYYY-MM-DD). Only used when `range` is true. */
+  @Prop({ mutable: true, reflect: true }) valueEnd?: string;
+
   /** Emitted when a date is selected. */
-  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string }>;
+  @Event({ eventName: 'tsChange' }) tsChange!: EventEmitter<{ value: string; valueEnd?: string }>;
 
   /** Whether the calendar dropdown is open. */
   @State() isOpen = false;
@@ -97,6 +109,14 @@ export class TsDatePicker {
     this.focusedDay = null;
   };
 
+  private prevYear = (): void => {
+    this.viewYear -= 1;
+  };
+
+  private nextYear = (): void => {
+    this.viewYear += 1;
+  };
+
   private prevMonth = (): void => {
     if (this.viewMonth === 0) {
       this.viewMonth = 11;
@@ -115,14 +135,39 @@ export class TsDatePicker {
     }
   };
 
-  private selectDay = (day: number): void => {
+  private formatDateStr(day: number): string {
     const month = String(this.viewMonth + 1).padStart(2, '0');
     const dayStr = String(day).padStart(2, '0');
-    const newValue = `${this.viewYear}-${month}-${dayStr}`;
-    this.value = newValue;
-    this.tsChange.emit({ value: newValue });
-    this.closeCalendar();
-    this.triggerEl?.focus();
+    return `${this.viewYear}-${month}-${dayStr}`;
+  }
+
+  private selectDay = (day: number): void => {
+    const newValue = this.formatDateStr(day);
+
+    if (this.range) {
+      if (!this.value || (this.value && this.valueEnd)) {
+        // Start new range
+        this.value = newValue;
+        this.valueEnd = undefined;
+      } else {
+        // Set end of range
+        if (newValue < this.value) {
+          // Clicked before start — swap
+          this.valueEnd = this.value;
+          this.value = newValue;
+        } else {
+          this.valueEnd = newValue;
+        }
+        this.tsChange.emit({ value: this.value, valueEnd: this.valueEnd });
+        this.closeCalendar();
+        this.triggerEl?.focus();
+      }
+    } else {
+      this.value = newValue;
+      this.tsChange.emit({ value: newValue });
+      this.closeCalendar();
+      this.triggerEl?.focus();
+    }
   };
 
   private isDayDisabled(day: number): boolean {
@@ -155,12 +200,37 @@ export class TsDatePicker {
     return new Date(this.viewYear, this.viewMonth + 1, 0).getDate();
   }
 
-  private getFirstDayOfWeek(): number {
-    return new Date(this.viewYear, this.viewMonth, 1).getDay();
+  private getFirstDayOffset(): number {
+    const dayOfWeek = new Date(this.viewYear, this.viewMonth, 1).getDay();
+    return (dayOfWeek - this.firstDayOfWeek + 7) % 7;
+  }
+
+  private getWeekdayHeaders(): string[] {
+    const shifted: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      shifted.push(DEFAULT_WEEKDAYS[(this.firstDayOfWeek + i) % 7]);
+    }
+    return shifted;
   }
 
   private getMonthName(): string {
-    return new Date(this.viewYear, this.viewMonth).toLocaleString('default', { month: 'long' });
+    return new Date(this.viewYear, this.viewMonth).toLocaleString(this.locale, { month: 'long' });
+  }
+
+  private isInRange(day: number): boolean {
+    if (!this.range || !this.value || !this.valueEnd) return false;
+    const dateStr = this.formatDateStr(day);
+    return dateStr > this.value && dateStr < this.valueEnd;
+  }
+
+  private isRangeStart(day: number): boolean {
+    if (!this.range || !this.value) return false;
+    return this.formatDateStr(day) === this.value;
+  }
+
+  private isRangeEnd(day: number): boolean {
+    if (!this.range || !this.valueEnd) return false;
+    return this.formatDateStr(day) === this.valueEnd;
   }
 
   private handleTriggerKeydown = (event: KeyboardEvent): void => {
@@ -236,10 +306,11 @@ export class TsDatePicker {
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   private renderCalendar() {
     const daysInMonth = this.getDaysInMonth();
-    const firstDay = this.getFirstDayOfWeek();
+    const firstDayOffset = this.getFirstDayOffset();
+    const weekdayHeaders = this.getWeekdayHeaders();
     const days: (number | null)[] = [];
 
-    for (let i = 0; i < firstDay; i++) {
+    for (let i = 0; i < firstDayOffset; i++) {
       days.push(null);
     }
     for (let d = 1; d <= daysInMonth; d++) {
@@ -255,30 +326,50 @@ export class TsDatePicker {
         onKeyDown={this.handleCalendarKeydown}
       >
         <div class="date-picker__header" part="header">
-          <button
-            class="date-picker__nav-btn"
-            type="button"
-            aria-label="Previous month"
-            onClick={this.prevMonth}
-          >
-            &#x2039;
-          </button>
+          <div class="date-picker__nav-group">
+            <button
+              class="date-picker__nav-btn"
+              type="button"
+              aria-label="Previous year"
+              onClick={this.prevYear}
+            >
+              &#x00AB;
+            </button>
+            <button
+              class="date-picker__nav-btn"
+              type="button"
+              aria-label="Previous month"
+              onClick={this.prevMonth}
+            >
+              &#x2039;
+            </button>
+          </div>
           <span class="date-picker__month-year">
             {this.getMonthName()} {this.viewYear}
           </span>
-          <button
-            class="date-picker__nav-btn"
-            type="button"
-            aria-label="Next month"
-            onClick={this.nextMonth}
-          >
-            &#x203A;
-          </button>
+          <div class="date-picker__nav-group">
+            <button
+              class="date-picker__nav-btn"
+              type="button"
+              aria-label="Next month"
+              onClick={this.nextMonth}
+            >
+              &#x203A;
+            </button>
+            <button
+              class="date-picker__nav-btn"
+              type="button"
+              aria-label="Next year"
+              onClick={this.nextYear}
+            >
+              &#x00BB;
+            </button>
+          </div>
         </div>
 
         <div class="date-picker__grid" role="grid" aria-label="Calendar">
           <div class="date-picker__weekdays">
-            {WEEKDAYS.map((wd) => (
+            {weekdayHeaders.map((wd) => (
               <span class="date-picker__weekday" role="columnheader" key={wd}>
                 {wd}
               </span>
@@ -296,6 +387,9 @@ export class TsDatePicker {
                     'date-picker__day--selected': this.isSelected(day),
                     'date-picker__day--disabled': this.isDayDisabled(day),
                     'date-picker__day--focused': this.focusedDay === day,
+                    'date-picker__day--in-range': this.isInRange(day),
+                    'date-picker__day--range-start': this.isRangeStart(day),
+                    'date-picker__day--range-end': this.isRangeEnd(day),
                   }}
                   part="day"
                   type="button"
@@ -340,7 +434,7 @@ export class TsDatePicker {
           type="text"
           id={this.pickerId}
           name={this.name}
-          value={this.value || ''}
+          value={this.range && this.value && this.valueEnd ? `${this.value} — ${this.valueEnd}` : this.value || ''}
           placeholder={this.placeholder}
           disabled={this.disabled}
           readOnly


### PR DESCRIPTION
## Summary
- Add `range` prop with start/end date selection and visual range highlighting
- Add year navigation buttons (`<<`/`>>`) alongside month navigation
- Add `locale` and `firstDayOfWeek` props for internationalization

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)