### PR TITLE
fix: fix Storybook build and docs generation for release CI

### DIFF
--- a/docs/scripts/generate-component-docs.mjs
+++ b/docs/scripts/generate-component-docs.mjs
@@ -90,7 +90,7 @@ for (const component of docs.components) {
     lines.push('| Event | Detail | Bubbles | Composed | Description |');
     lines.push('|---|---|---|---|---|');
     for (const event of events) {
-      const detail = event.detail ? `\`${event.detail}\`` : '—';
+      const detail = event.detail ? `\`${event.detail.replace(/\{/g, '\\{').replace(/\}/g, '\\}')}\`` : '—';
       const doc = escapeMarkdown(event.docs || '');
       lines.push(`| \`${event.event}\` | ${detail} | ${event.bubbles ? 'Yes' : 'No'} | ${event.composed ? 'Yes' : 'No'} | ${doc} |`);
     }
@@ -213,5 +213,9 @@ function pascalCase(str) {
 }
 
 function escapeMarkdown(str) {
-  return str.replace(/\|/g, '\\|').replace(/\n/g, ' ');
+  return str
+    .replace(/\|/g, '\\|')
+    .replace(/\n/g, ' ')
+    .replace(/\{/g, '\\{')
+    .replace(/\}/g, '\\}');
 }

--- a/src/components/avatar-group/avatar-group.stories.ts
+++ b/src/components/avatar-group/avatar-group.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the parent component's stories file (avatar.stories.ts)
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/AvatarGroup',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/src/components/checkbox-group/checkbox-group.stories.ts
+++ b/src/components/checkbox-group/checkbox-group.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the checkbox component's stories file
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/CheckboxGroup',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/src/components/command-palette/command-palette-item.stories.ts
+++ b/src/components/command-palette/command-palette-item.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the parent component's stories file
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/CommandPaletteItem',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/src/components/menu/menu-divider.stories.ts
+++ b/src/components/menu/menu-divider.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the menu component's stories file
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/MenuDivider',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/src/components/radio-group/radio-group.stories.ts
+++ b/src/components/radio-group/radio-group.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the radio component's stories file
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/RadioGroup',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};

--- a/src/components/timeline/timeline-item.stories.ts
+++ b/src/components/timeline/timeline-item.stories.ts
@@ -1,1 +1,7 @@
-// Stories for this component are in the parent component's stories file
+// Stories for this component are in the parent's stories file
+
+export default {
+  title: 'Components/TimelineItem',
+  tags: ['!autodocs'],
+  parameters: { chromatic: { disableSnapshot: true } },
+};


### PR DESCRIPTION
## Summary
Fix two issues blocking the release workflow:

1. **Storybook build failure** — 6 stub story files (compound component children) had only a comment, no default export. Storybook 10 CSF requires `export default`. Fixed with minimal valid CSF exports.

2. **Docs build failure** — Auto-generated MDX pages contained unescaped `{` `}` in event detail types (e.g., `{ source: "overlay" }`), which MDX/JSX treated as expressions. Fixed `escapeMarkdown()` in the docs generator.

## Verified locally
All release steps pass:
- `pnpm build` — 71 components
- Wrapper builds (react, vue, angular)
- `pnpm build-storybook` — Storybook 10 build succeeds
- `pnpm -C docs build` — 93 pages, 71 component docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)