### PR TITLE
fix: move exports comment out of exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "**/*.css",
     "dist/tessera-ui/tessera-ui.esm.js"
   ],
+  "_exportsComment": "The ./dist/* glob passthrough is required by framework wrapper packages (react/vue/angular) which deep-import from @tessera-ui/core/dist/. Do not remove it.",
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "require": "./dist/index.cjs.js",
       "types": "./dist/types/index.d.ts"
     },
-    "_comment_dist_glob": "Required: framework wrappers (react/vue/angular) import from @tessera-ui/core/dist/. Removing this breaks all wrapper packages.",
     "./dist/*": "./dist/*",
     "./loader": {
       "import": "./loader/index.js",


### PR DESCRIPTION
## Summary
Move `_comment_dist_glob` from inside the `exports` object to a top-level `_exportsComment` field. The mixed key types (subpath `.` keys + non-subpath comment key) violated the Node.js exports spec and broke Vite 8+ resolution.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)