### PR TITLE
fix: resolve 8 component bugs from v0.6.1

### DIFF
--- a/src/components/app-layout/app-layout.css
+++ b/src/components/app-layout/app-layout.css
@@ -34,4 +34,5 @@
 
 .app-layout__content {
   flex: 1;
+  padding: var(--ts-spacing-6);
 }

--- a/src/components/banner/banner.css
+++ b/src/components/banner/banner.css
@@ -31,6 +31,7 @@
   font-size: var(--ts-font-size-sm);
   line-height: var(--ts-line-height-normal);
   inline-size: 100%;
+  box-sizing: border-box;
 }
 
 /* ---- Variants ---- */

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -10,6 +10,7 @@
 :host {
   display: block;
   font-family: var(--ts-font-family-base);
+  color: var(--ts-color-text-primary);
 
   --ts-card-bg: var(--ts-color-bg-elevated);
   --ts-card-radius: var(--ts-shape-container);
@@ -75,7 +76,8 @@
   border-bottom: 1px solid var(--ts-card-border-color);
 }
 
-.card__header:empty {
+.card__header:empty,
+.card__header:not(:has(::slotted(*))) {
   display: none;
   border-bottom: none;
 }

--- a/src/components/page-header/page-header.css
+++ b/src/components/page-header/page-header.css
@@ -1,6 +1,7 @@
 :host {
   display: block;
   font-family: var(--ts-font-family-base);
+  color: var(--ts-color-text-primary);
 }
 
 .page-header__main {

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -13,7 +13,9 @@
   border-inline-end: 1px solid var(--ts-color-border-default);
   background: var(--ts-color-bg-surface);
   font-family: var(--ts-font-family-base);
-  block-size: 100%;
+  block-size: 100vh;
+  position: sticky;
+  inset-block-start: 0;
   transition: width var(--ts-transition-normal);
   overflow: hidden;
   flex-shrink: 0;
@@ -112,6 +114,17 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+:host([collapsed]) .sidebar__content ::slotted(*) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Hide text in nav items when collapsed — show only icons */
+:host([collapsed]) {
+  --ts-sidebar-label-display: none;
 }
 
 /* ---- Reduced motion ---- */


### PR DESCRIPTION
## Summary
Fix all 8 bugs reported in #117:

| Bug | Component | Fix |
|---|---|---|
| 1 | PageHeader | Add `color: var(--ts-color-text-primary)` on `:host` for dark mode |
| 2 | Card | Add `color: var(--ts-color-text-primary)` on `:host` for dark mode |
| 3 | Banner | Add `box-sizing: border-box` to prevent horizontal overflow |
| 4 | Card | Use `:not(:has(::slotted(*)))` to collapse empty header |
| 5 | AppLayout | Add default `padding: var(--ts-spacing-6)` to content area |
| 6 | Sidebar | Add `--ts-sidebar-label-display` CSS prop for collapsed label hiding |
| 7 | Sidebar | Change to `position: sticky; height: 100vh` for viewport-fixed sidebar |
| 8 | Sidebar | Same fix as #7 — footer now stays at viewport bottom |

## Test plan
- [x] 34 unit tests pass across all 5 affected components
- [x] Build passes

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)