### PR TITLE
fix: add dist entry points to sideEffects to prevent tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   ],
   "sideEffects": [
     "**/*.css",
+    "dist/index.js",
+    "dist/index.cjs.js",
+    "dist/esm/loader.js",
     "dist/tessera-ui/tessera-ui.esm.js"
   ],
   "_exportsComment": "The ./dist/* glob passthrough is required by framework wrapper packages (react/vue/angular) which deep-import from @tessera-ui/core/dist/. Do not remove it.",


### PR DESCRIPTION
## Root Cause

`dist/index.js` (which calls `defineCustomElements()`) was not in the `sideEffects` array in `package.json`. When Vite/Rollup sees `import '@tessera-ui/core'` with no used exports, it checks `sideEffects`, doesn't find `dist/index.js`, and **tree-shakes the entire import away** — including the `defineCustomElements()` call that registers components and injects design tokens.

Result: components render as empty custom elements with no styles because all `var(--ts-*)` tokens resolve to nothing.

## Fix

Add the entry points with side effects to the array:
```json
"sideEffects": [
  "**/*.css",
  "dist/index.js",
  "dist/index.cjs.js",
  "dist/esm/loader.js",
  "dist/tessera-ui/tessera-ui.esm.js"
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)