### PR TITLE
chore(release): publish v0.6.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tessera-ui/core",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Production-ready UI component library for React, Vue, Angular, and vanilla HTML",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tessera-ui/angular",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Tessera UI components for Angular",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tessera-ui/react",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Tessera UI components for React",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tessera-ui/vue",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Tessera UI components for Vue",
   "main": "dist/cjs/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Release v0.6.3

### Changes since v0.6.2
- **CSS import in dist** — bundlers now extract design tokens as a real `.css` file
- **E2E retry** — `jest.retryTimes(5)` for flaky test resilience
- **Pre-commit hook** — lint staged `.ts`/`.tsx` files
- **Integration test** — verifies all 4 framework packages build correctly with Vite
- **Docs** — restructured installation/usage pages with per-framework setup guides
- **Messaging** — aligned all docs/README to position Tessera UI as a component library
- **CI** — removed flaky install timeouts